### PR TITLE
Bump MSRV to 1.81, fix lints, improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
   test:
@@ -36,13 +37,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
       - run: cargo test --doc
 
   msrv:
-    name: MSRV (1.70)
+    name: MSRV (1.81)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@1.81
+      - uses: Swatinem/rust-cache@v2
       - run: cargo build --all-features
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +277,7 @@ dependencies = [
 name = "transfinite"
 version = "0.2.0"
 dependencies = [
+ "cargo-husky",
  "num-traits",
  "proptest",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/transfinite"
 homepage = "https://github.com/niarenaw/rust-transfinite"
 keywords = ["ordinal", "transfinite", "mathematics", "cantor", "ordinal-arithmetic"]
 categories = ["mathematics", "algorithms"]
-rust-version = "1.70"
+rust-version = "1.81"
 
 [dependencies]
 num-traits = "0.2.19"
@@ -19,3 +19,4 @@ thiserror = "2.0.11"
 
 [dev-dependencies]
 proptest = "1.4"
+cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"] }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -153,7 +153,10 @@ mod tests {
 
     #[test]
     fn test_single_omega() {
-        assert_eq!(OrdinalBuilder::new().omega().build().unwrap(), Ordinal::omega());
+        assert_eq!(
+            OrdinalBuilder::new().omega().build().unwrap(),
+            Ordinal::omega()
+        );
     }
 
     #[test]
@@ -164,7 +167,10 @@ mod tests {
 
     #[test]
     fn test_finite_only() {
-        assert_eq!(OrdinalBuilder::new().plus(42).build().unwrap(), Ordinal::new_finite(42));
+        assert_eq!(
+            OrdinalBuilder::new().plus(42).build().unwrap(),
+            Ordinal::new_finite(42)
+        );
     }
 
     #[test]
@@ -180,14 +186,19 @@ mod tests {
             CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap(),
             CnfTerm::new(&Ordinal::one(), 3).unwrap(),
             CnfTerm::new_finite(7),
-        ]).unwrap();
+        ])
+        .unwrap();
 
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_rejects_wrong_order() {
-        assert!(OrdinalBuilder::new().omega().omega_power(2).build().is_err());
+        assert!(OrdinalBuilder::new()
+            .omega()
+            .omega_power(2)
+            .build()
+            .is_err());
     }
 
     #[test]
@@ -198,6 +209,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_build_unchecked_panics() {
-        OrdinalBuilder::new().omega().omega_power(2).build_unchecked();
+        OrdinalBuilder::new()
+            .omega()
+            .omega_power(2)
+            .build_unchecked();
     }
 }

--- a/src/cnfterm.rs
+++ b/src/cnfterm.rs
@@ -317,7 +317,6 @@ impl Ord for CnfTerm {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/comprehensive_tests.rs
+++ b/tests/comprehensive_tests.rs
@@ -38,14 +38,14 @@ mod ordinal_properties {
 
     #[test]
     fn test_transfinite_empty_terms_fails() {
-        let result = Ordinal::new_transfinite(&vec![]);
+        let result = Ordinal::new_transfinite(&[]);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_transfinite_finite_leading_term_fails() {
         let finite_term = CnfTerm::new_finite(42);
-        let result = Ordinal::new_transfinite(&vec![finite_term]);
+        let result = Ordinal::new_transfinite(&[finite_term]);
         assert!(result.is_err());
     }
 
@@ -87,7 +87,7 @@ mod ordinal_properties {
     fn test_equality() {
         let omega1 = Ordinal::omega();
         let omega2 =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::one(), 1).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 1).unwrap()]).unwrap();
 
         assert_eq!(omega1, omega2);
 
@@ -192,12 +192,11 @@ mod ordinal_properties {
     fn test_addition_omega_cases() {
         let omega = Ordinal::omega();
         let omega_squared =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()])
-                .unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
 
         // ω + ω = ω·2
         let two_omega =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
         assert_eq!(omega.clone() + omega.clone(), two_omega);
 
         // ω + ω² = ω²
@@ -288,7 +287,7 @@ mod ordinal_properties {
 
         // ω · 2 = ω + ω = ω·2
         let two_omega =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
         assert_eq!(omega.clone() * two.clone(), two_omega);
 
         // They're different!
@@ -314,13 +313,12 @@ mod ordinal_properties {
 
         // ω · ω = ω²
         let omega_squared =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()])
-                .unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
         assert_eq!(omega.clone() * omega.clone(), omega_squared);
 
         // ω · 3 = ω + ω + ω
         let three_omega =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::one(), 3).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 3).unwrap()]).unwrap();
         assert_eq!(omega.clone() * Ordinal::new_finite(3), three_omega);
     }
 
@@ -422,13 +420,12 @@ mod ordinal_properties {
 
         // ω^2 = ω · ω
         let omega_squared =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()])
-                .unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
         assert_eq!(omega.clone().pow(Ordinal::new_finite(2)), omega_squared);
 
         // ω^ω
         let omega_omega =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&omega.clone(), 1).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&omega.clone(), 1).unwrap()]).unwrap();
         assert_eq!(omega.clone().pow(omega.clone()), omega_omega);
 
         // 2^ω = ω (any finite^ω = ω for finite ≥ 2)
@@ -444,40 +441,38 @@ mod ordinal_properties {
         let omega_plus_1 = omega.clone() + Ordinal::one();
         let result = omega.clone().pow(omega_plus_1.clone());
         let expected =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&omega_plus_1, 1).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&omega_plus_1, 1).unwrap()]).unwrap();
         assert_eq!(result, expected);
 
         // w^(w*2) in CNF has exponent w*2
         let omega_times_2 =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
         let result = omega.clone().pow(omega_times_2.clone());
         let expected =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&omega_times_2, 1).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&omega_times_2, 1).unwrap()]).unwrap();
         assert_eq!(result, expected);
 
         // (w+1)^w = w^w (successor base to limit exponent)
         let omega_plus_1 = omega.clone() + Ordinal::one();
         let result = omega_plus_1.clone().pow(omega.clone());
         let omega_omega =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&omega.clone(), 1).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&omega.clone(), 1).unwrap()]).unwrap();
         assert_eq!(result, omega_omega);
 
         // 2^(w^2) = w^w
         let omega_squared =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()])
-                .unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
         let result = Ordinal::new_finite(2).pow(omega_squared.clone());
         let omega_omega =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&omega.clone(), 1).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&omega.clone(), 1).unwrap()]).unwrap();
         assert_eq!(result, omega_omega);
 
         // w^(w^2) - exponent is itself transfinite
         let omega_squared =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()])
-                .unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
         let result = omega.clone().pow(omega_squared.clone());
         let expected =
-            Ordinal::new_transfinite(&vec![CnfTerm::new(&omega_squared, 1).unwrap()]).unwrap();
+            Ordinal::new_transfinite(&[CnfTerm::new(&omega_squared, 1).unwrap()]).unwrap();
         assert_eq!(result, expected);
     }
 
@@ -632,10 +627,10 @@ mod ordinal_properties {
     #[test]
     fn test_complex_ordinal_construction() {
         // Build ω² + ω·3 + 7
-        let complex = Ordinal::new_transfinite(&vec![
+        let complex = Ordinal::new_transfinite(&[
             CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap(), // ω²
             CnfTerm::new(&Ordinal::one(), 3).unwrap(),         // ω·3
-            CnfTerm::new_finite(7),                            // 7
+            CnfTerm::new_finite(7),
         ])
         .unwrap();
 
@@ -647,14 +642,14 @@ mod ordinal_properties {
     #[test]
     fn test_complex_arithmetic() {
         // (ω² + ω + 1) + (ω² + 5) = ω²·2 + 5 (adds leading terms with same exponent)
-        let ord1 = Ordinal::new_transfinite(&vec![
+        let ord1 = Ordinal::new_transfinite(&[
             CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap(),
             CnfTerm::new(&Ordinal::one(), 1).unwrap(),
             CnfTerm::new_finite(1),
         ])
         .unwrap();
 
-        let ord2 = Ordinal::new_transfinite(&vec![
+        let ord2 = Ordinal::new_transfinite(&[
             CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap(),
             CnfTerm::new_finite(5),
         ])
@@ -663,7 +658,7 @@ mod ordinal_properties {
         let sum = ord1 + ord2.clone();
 
         // Result should be ω²·2 + 5
-        let expected = Ordinal::new_transfinite(&vec![
+        let expected = Ordinal::new_transfinite(&[
             CnfTerm::new(&Ordinal::new_finite(2), 2).unwrap(),
             CnfTerm::new_finite(5),
         ])

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -266,7 +266,7 @@ fn test_antisymmetry() {
 
     // If a < b, then !(b < a)
     assert!(five < ten);
-    assert!(!(ten < five));
+    assert!((ten >= five));
 }
 
 // ========================================

--- a/tests/real_example_tests.rs
+++ b/tests/real_example_tests.rs
@@ -15,8 +15,8 @@ mod tests {
         let five = &two + &three;
 
         let omega = Ordinal::omega();
-        let omega_2 = Ordinal::new_transfinite(&vec![CnfTerm::new(&two, 1).unwrap()]).unwrap();
-        let omega_3 = Ordinal::new_transfinite(&vec![CnfTerm::new(&three, 1).unwrap()]).unwrap();
+        let omega_2 = Ordinal::new_transfinite(&[CnfTerm::new(&two, 1).unwrap()]).unwrap();
+        let omega_3 = Ordinal::new_transfinite(&[CnfTerm::new(&three, 1).unwrap()]).unwrap();
 
         let lhs = &omega_2 + &omega + one;
         let rhs = omega_3.clone() + omega;
@@ -33,13 +33,13 @@ mod tests {
 
     #[test]
     fn exponentiation() {
-        let base = Ordinal::new_transfinite(&vec![
+        let base = Ordinal::new_transfinite(&[
             CnfTerm::new(&Ordinal::new_finite(5), 1).unwrap(),
             CnfTerm::new(&Ordinal::new_finite(3), 1).unwrap(),
         ])
         .unwrap();
         let expr = base.pow(Ordinal::new_finite(3));
-        let expected = Ordinal::new_transfinite(&vec![
+        let expected = Ordinal::new_transfinite(&[
             CnfTerm::new(&Ordinal::new_finite(15), 1).unwrap(),
             CnfTerm::new(&Ordinal::new_finite(13), 1).unwrap(),
         ])


### PR DESCRIPTION
- Update rust-version to 1.81 to support thiserror 2.x
- Fix clippy warnings: replace &vec![] with &[], simplify boolean expressions
- Apply cargo fmt formatting fixes
- Add Swatinem/rust-cache to CI jobs for faster builds
- Add security audit job using rustsec/audit-check
- Add cargo-husky for pre-commit hooks (runs clippy + fmt)