### PR TITLE
Release 0.2.1: Documentation & Test Modernization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "transfinite"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cargo-husky",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfinite"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["niarenaw"]
 license = "MIT OR Apache-2.0"

--- a/examples/exponentiation.rs
+++ b/examples/exponentiation.rs
@@ -19,29 +19,29 @@
 //! ```
 
 use num_traits::Pow;
-use transfinite::{CnfTerm, Ordinal};
+use transfinite::Ordinal;
 
 fn main() {
-    // Construct the base ordinal: ω³ + ω
-    let base = Ordinal::new_transfinite(&[
-        CnfTerm::new(&Ordinal::new_finite(3), 1).unwrap(), // ω³
-        CnfTerm::new(&Ordinal::new_finite(1), 1).unwrap(), // ω
-    ])
-    .unwrap();
+    // Construct the base ordinal: ω³ + ω using the builder API
+    let base = Ordinal::builder()
+        .omega_power(3) // ω³
+        .omega() // + ω
+        .build()
+        .unwrap();
 
     println!("Base ordinal: {}", base);
     println!("Computing: ({})^5", base);
     println!();
 
     // Compute (ω³ + ω)⁵
-    let result = base.pow(Ordinal::new_finite(5));
+    let result = base.pow(Ordinal::from(5));
 
     // Expected result: ω¹⁵ + ω¹³
-    let expected = Ordinal::new_transfinite(&[
-        CnfTerm::new(&Ordinal::new_finite(15), 1).unwrap(), // ω¹⁵
-        CnfTerm::new(&Ordinal::new_finite(13), 1).unwrap(), // ω¹³
-    ])
-    .unwrap();
+    let expected = Ordinal::builder()
+        .omega_power(15) // ω¹⁵
+        .omega_power(13) // + ω¹³
+        .build()
+        .unwrap();
 
     println!("Result:   {}", result);
     println!("Expected: {}", expected);

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 pub enum OrdinalError {
     /// Error when constructing a CNF term with invalid parameters.
     ///
-    /// This error occurs when attempting to create a [`CnfTerm`]
+    /// This error occurs when attempting to create a [`CnfTerm`](crate::CnfTerm)
     /// with a multiplicity of 0. In Cantor Normal Form, all coefficients must be
     /// positive (non-zero).
     ///
@@ -53,14 +53,14 @@ pub enum OrdinalError {
 
     /// Error when constructing a transfinite ordinal with invalid terms.
     ///
-    /// This error occurs when attempting to create a transfinite [`Ordinal`]
+    /// This error occurs when attempting to create a transfinite [`Ordinal`](crate::Ordinal)
     /// with terms that violate CNF requirements.
     ///
     /// # Common Causes
     ///
     /// 1. **Empty terms vector**: Transfinite ordinals must have at least one term
     /// 2. **Leading term is finite**: The first term must have a non-zero exponent
-    ///    (use [`Ordinal::new_finite`] for finite ordinals)
+    ///    (use [`Ordinal::new_finite`](crate::Ordinal::new_finite) for finite ordinals)
     ///
     /// # How to Avoid
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,14 +99,15 @@
 //! This library uses CNF internally for efficient arithmetic:
 //!
 //! ```
-//! use transfinite::{Ordinal, CnfTerm};
+//! use transfinite::Ordinal;
 //!
-//! // Construct ω² + ω·3 + 7 using CNF terms
-//! let ordinal = Ordinal::new_transfinite(&vec![
-//!     CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap(),  // ω²
-//!     CnfTerm::new(&Ordinal::one(), 3).unwrap(),          // ω·3
-//!     CnfTerm::new_finite(7),                             // 7
-//! ]).unwrap();
+//! // Construct ω² + ω·3 + 7 using the builder API
+//! let ordinal = Ordinal::builder()
+//!     .omega_power(2)    // ω²
+//!     .omega_times(3)    // ω·3
+//!     .plus(7)           // 7
+//!     .build()
+//!     .unwrap();
 //!
 //! println!("{}", ordinal);  // Prints: ω^2 + ω * 3 + 7
 //! ```
@@ -137,6 +138,7 @@
 //! # Core Types
 //!
 //! - [`Ordinal`] - Main ordinal number type (finite or transfinite)
+//! - [`OrdinalBuilder`] - Fluent builder for constructing complex ordinals
 //! - [`CnfTerm`] - A term in Cantor Normal Form (ω^exponent · multiplicity)
 //! - [`OrdinalError`] - Error type for construction failures
 //! - [`Result<T>`] - Type alias for `Result<T, OrdinalError>`
@@ -194,7 +196,8 @@
 //!
 //! - Finite ordinals use native `u32` for efficient storage and arithmetic
 //! - Transfinite ordinals store CNF terms in a vector (most have 1-3 terms)
-//! - Arithmetic operations clone data when needed; use references to minimize cloning
+//! - Arithmetic operations clone data when needed; use references (`&Ordinal`) to minimize cloning
+//! - For CNF term inspection, use [`CnfTerm::exponent_ref()`] to avoid cloning the exponent
 //! - Exponentiation with finite exponents uses O(log n) binary exponentiation
 //!
 //! # Mathematical Background

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -206,6 +206,11 @@ impl Ordinal {
     /// 3. Terms are in strictly decreasing order by exponent (CNF requirement)
     ///
     /// If any validation fails, returns `Err(OrdinalError::TransfiniteConstructionError)`.
+    ///
+    /// # See Also
+    ///
+    /// For a more ergonomic API, see [`Ordinal::builder`] which provides a fluent
+    /// interface for constructing ordinals without manually creating [`CnfTerm`]s.
     pub fn new_transfinite(terms: &[CnfTerm]) -> Result<Self> {
         // Validate terms vector is non-empty
         match terms.first() {
@@ -557,7 +562,7 @@ impl Ordinal {
         Ordinal::new_transfinite(&[omega_term]).unwrap()
     }
 
-    /// Creates a new [`OrdinalBuilder`] for fluent ordinal construction.
+    /// Creates a new [`OrdinalBuilder`](crate::OrdinalBuilder) for fluent ordinal construction.
     ///
     /// # Example
     ///

--- a/tests/comprehensive_tests.rs
+++ b/tests/comprehensive_tests.rs
@@ -86,8 +86,7 @@ mod ordinal_properties {
     #[test]
     fn test_equality() {
         let omega1 = Ordinal::omega();
-        let omega2 =
-            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 1).unwrap()]).unwrap();
+        let omega2 = Ordinal::builder().omega().build().unwrap();
 
         assert_eq!(omega1, omega2);
 
@@ -191,12 +190,10 @@ mod ordinal_properties {
     #[test]
     fn test_addition_omega_cases() {
         let omega = Ordinal::omega();
-        let omega_squared =
-            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
+        let omega_squared = Ordinal::builder().omega_power(2).build().unwrap();
 
         // ω + ω = ω·2
-        let two_omega =
-            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
+        let two_omega = Ordinal::builder().omega_times(2).build().unwrap();
         assert_eq!(omega.clone() + omega.clone(), two_omega);
 
         // ω + ω² = ω²
@@ -279,15 +276,14 @@ mod ordinal_properties {
     #[test]
     fn test_multiplication_non_commutative() {
         // Ordinal multiplication is NOT commutative
-        let two = Ordinal::new_finite(2);
+        let two: Ordinal = 2.into();
         let omega = Ordinal::omega();
 
         // 2 · ω = ω (finite multiple absorbed)
         assert_eq!(two.clone() * omega.clone(), omega);
 
         // ω · 2 = ω + ω = ω·2
-        let two_omega =
-            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 2).unwrap()]).unwrap();
+        let two_omega = Ordinal::builder().omega_times(2).build().unwrap();
         assert_eq!(omega.clone() * two.clone(), two_omega);
 
         // They're different!
@@ -312,13 +308,11 @@ mod ordinal_properties {
         let omega = Ordinal::omega();
 
         // ω · ω = ω²
-        let omega_squared =
-            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
+        let omega_squared = Ordinal::builder().omega_power(2).build().unwrap();
         assert_eq!(omega.clone() * omega.clone(), omega_squared);
 
         // ω · 3 = ω + ω + ω
-        let three_omega =
-            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::one(), 3).unwrap()]).unwrap();
+        let three_omega = Ordinal::builder().omega_times(3).build().unwrap();
         assert_eq!(omega.clone() * Ordinal::new_finite(3), three_omega);
     }
 
@@ -419,13 +413,11 @@ mod ordinal_properties {
         let omega = Ordinal::omega();
 
         // ω^2 = ω · ω
-        let omega_squared =
-            Ordinal::new_transfinite(&[CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap()]).unwrap();
-        assert_eq!(omega.clone().pow(Ordinal::new_finite(2)), omega_squared);
+        let omega_squared = Ordinal::builder().omega_power(2).build().unwrap();
+        assert_eq!(omega.clone().pow(Ordinal::from(2)), omega_squared);
 
         // ω^ω
-        let omega_omega =
-            Ordinal::new_transfinite(&[CnfTerm::new(&omega.clone(), 1).unwrap()]).unwrap();
+        let omega_omega = Ordinal::builder().omega_exp(omega.clone()).build().unwrap();
         assert_eq!(omega.clone().pow(omega.clone()), omega_omega);
 
         // 2^ω = ω (any finite^ω = ω for finite ≥ 2)

--- a/tests/real_example_tests.rs
+++ b/tests/real_example_tests.rs
@@ -5,46 +5,49 @@
 mod tests {
 
     use num_traits::Pow;
-    use transfinite::*;
+    use transfinite::Ordinal;
 
     #[test]
     fn multiplication() {
-        let one = Ordinal::one();
-        let two = &one + &one;
-        let three = &one + &two;
-        let five = &two + &three;
-
+        // Using builder for transfinite ordinals
         let omega = Ordinal::omega();
-        let omega_2 = Ordinal::new_transfinite(&[CnfTerm::new(&two, 1).unwrap()]).unwrap();
-        let omega_3 = Ordinal::new_transfinite(&[CnfTerm::new(&three, 1).unwrap()]).unwrap();
+        let omega_2 = Ordinal::builder().omega_power(2).build().unwrap();
+        let omega_3 = Ordinal::builder().omega_power(3).build().unwrap();
 
-        let lhs = &omega_2 + &omega + one;
+        // (ω² + ω + 1) * (ω³ + ω)
+        let lhs = &omega_2 + &omega + Ordinal::one();
         let rhs = omega_3.clone() + omega;
 
         let expr = lhs * rhs;
-        let expected_terms = vec![
-            CnfTerm::new(&five, 1).unwrap(),
-            CnfTerm::new(&three, 1).unwrap(),
-        ];
-        let expected = Ordinal::new_transfinite(&expected_terms).unwrap();
 
-        assert_eq!(expr, expected)
+        // Expected: ω⁵ + ω³
+        let expected = Ordinal::builder()
+            .omega_power(5)
+            .omega_power(3)
+            .build()
+            .unwrap();
+
+        assert_eq!(expr, expected);
     }
 
     #[test]
     fn exponentiation() {
-        let base = Ordinal::new_transfinite(&[
-            CnfTerm::new(&Ordinal::new_finite(5), 1).unwrap(),
-            CnfTerm::new(&Ordinal::new_finite(3), 1).unwrap(),
-        ])
-        .unwrap();
-        let expr = base.pow(Ordinal::new_finite(3));
-        let expected = Ordinal::new_transfinite(&[
-            CnfTerm::new(&Ordinal::new_finite(15), 1).unwrap(),
-            CnfTerm::new(&Ordinal::new_finite(13), 1).unwrap(),
-        ])
-        .unwrap();
+        // (ω⁵ + ω³)³ using builder
+        let base = Ordinal::builder()
+            .omega_power(5)
+            .omega_power(3)
+            .build()
+            .unwrap();
 
-        assert_eq!(expr, expected)
+        let expr = base.pow(Ordinal::from(3));
+
+        // Expected: ω¹⁵ + ω¹³
+        let expected = Ordinal::builder()
+            .omega_power(15)
+            .omega_power(13)
+            .build()
+            .unwrap();
+
+        assert_eq!(expr, expected);
     }
 }


### PR DESCRIPTION
## Summary

- Modernize documentation and examples to showcase 0.2.0 APIs (builder pattern, `From<u32>`, reference arithmetic)
- Bump version to 0.2.1
- Fix documentation warnings

## Changes

**README.md**
- Add new "Using the Builder API" section with comprehensive examples
- Update "Basic Example" to use `From<u32>` and reference arithmetic
- Replace verbose CNF construction with builder pattern in "Building Complex Ordinals"
- Add `Ordinal::builder()` to API Overview constructors list

**lib.rs (crate docs)**
- Update CNF example to use builder API
- Add `OrdinalBuilder` to Core Types list
- Add `exponent_ref()` mention in Performance Notes

**Examples & Tests**
- Modernize `examples/exponentiation.rs` to use builder
- Update `tests/real_example_tests.rs` with builder pattern
- Selectively update `tests/comprehensive_tests.rs` where builder improves clarity

**Other**
- Add cross-reference from `new_transfinite` docs to `Ordinal::builder`
- Fix 4 intra-doc link warnings in `error.rs` and `ordinal.rs`
- Bump version `0.2.0` → `0.2.1`

## Test plan

- [x] `cargo fmt` - passes
- [x] `cargo clippy` - no warnings
- [x] `cargo test` - all 128 tests pass
- [x] `cargo doc` - builds with no warnings
- [x] `cargo publish --dry-run` - package ready for publishing