### PR TITLE
Wave 1: Add --locked flag to cargo publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,6 @@ jobs:
           fi
 
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
Pin the published artifact to the exact dependency set verified in CI.

Without `--locked`, `cargo publish` regenerates the lockfile at publish time and may resolve newer transitive deps than were tested, producing publish-time drift between what CI verified and what landed on crates.io. `Cargo.lock` is committed in this repo, so `--locked` has real effect.

Part of the 0.3.0 release waves. See `~/.claude/plans/sunny-exploring-piglet.md` for the full plan.

## Test plan
- [ ] CI green on this PR
- [ ] Verified at real publish time (v0.3.0 tag) that the workflow succeeds