### PR TITLE
Wave 2: OrdinalBuilder::term docs + CHANGELOG comparison links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial public release with ordinal arithmetic up to ε₀.
+
+[0.2.2]: https://github.com/niarenaw/rust-transfinite/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/niarenaw/rust-transfinite/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/niarenaw/rust-transfinite/releases/tag/v0.2.0

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -48,8 +48,29 @@ impl OrdinalBuilder {
 
     /// Adds a CNF term with the given exponent and multiplicity.
     ///
-    /// Terms must be added in strictly decreasing exponent order.
-    /// If a term violates ordering or has zero multiplicity, an error is stored.
+    /// This is the lowest-level builder method; the convenience methods (`omega`,
+    /// `omega_power`, `omega_exp`, `plus`, and friends) all delegate to it. Reach
+    /// for `term` directly only when none of the convenience methods fit your
+    /// use case.
+    ///
+    /// Terms must be added in strictly decreasing exponent order. If a term
+    /// violates ordering or has zero multiplicity, the error is stored on the
+    /// builder and surfaced when [`build`](Self::build) is called rather than
+    /// panicking inline.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfinite::Ordinal;
+    ///
+    /// // ω² · 3 - equivalent to .omega_power_times(2, 3) but spelled in full.
+    /// let ordinal = Ordinal::builder()
+    ///     .term(Ordinal::new_finite(2), 3)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// assert!(ordinal.is_transfinite());
+    /// ```
     pub fn term(mut self, exponent: Ordinal, multiplicity: u32) -> Self {
         if self.error.is_some() {
             return self;


### PR DESCRIPTION
## Summary
- Add `# Examples` block to `OrdinalBuilder::term`, the lowest-level builder method (all other builder methods delegate to it).
- Add Keep-a-Changelog comparison links at the CHANGELOG footer so version headers link to the GitHub diff between releases.

Wave 9 will add `[0.3.0]` and `[Unreleased]` link entries when the version is cut.

## Test plan
- [x] `cargo test --doc builder` - all 12 builder doc tests pass, including the new one at `src/builder.rs:63`
- [ ] CI green on this PR