### PR TITLE
Wave 5a: Implement finite^transfinite-tower exponentiation

### DIFF
--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -894,20 +894,6 @@ impl Mul<&Ordinal> for &Ordinal {
 ///
 /// Finite ordinal exponentiation uses saturating arithmetic. Computing `m^n` for
 /// finite ordinals that would exceed `u32::MAX` returns `u32::MAX` instead of panicking.
-///
-/// # Panics
-///
-/// Panics when the base is finite (≥ 2) and the exponent is transfinite with
-/// a CNF term `ω^β · k` where `β` is itself transfinite. Examples:
-///
-/// - `2.pow(ω^ω · 3)`           - β = ω
-/// - `2.pow(ω^(ω+1))`           - β = ω+1
-/// - `2.pow(ω^ω + 5)`           - the leading term has β = ω
-///
-/// All other shapes are supported, including transfinite-base exponentiation
-/// like `ω.pow(ω^ω)` and finite-base with finite-tower exponents like
-/// `2.pow(ω^5 · 3)`. Implementation of the panicking case is tracked for a
-/// future release.
 impl Pow<Ordinal> for Ordinal {
     type Output = Self;
 
@@ -999,7 +985,21 @@ impl Pow<Ordinal> for Ordinal {
                                 )
                                 .expect("positive multiplicity for outer term")]);
                         } else {
-                            todo!("finite base with transfinite tower exponent (e.g., 2^(ω^ω·3))")
+                            // n^(ω^e · k) = ω^(ω^e · k) for transfinite e. The decrement
+                            // that the finite-e branch performs collapses here because
+                            // 1 + e = e for any transfinite e (left absorption of finite
+                            // into transfinite), so ω^(e-1) and ω^e coincide on this path.
+                            //
+                            // Reference: Carneiro,
+                            // https://math.stackexchange.com/q/2588262
+                            let inner_exp =
+                                Ordinal::transfinite_unchecked(vec![CnfTerm::from_parts(e, k)
+                                    .expect("positive multiplicity for inner exponent")]);
+                            distributed = distributed
+                                * Ordinal::transfinite_unchecked(vec![CnfTerm::from_parts(
+                                    inner_exp, 1,
+                                )
+                                .expect("positive multiplicity for outer term")]);
                         }
                     }
                 }

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -897,8 +897,17 @@ impl Mul<&Ordinal> for &Ordinal {
 ///
 /// # Panics
 ///
-/// Panics on finite base with a transfinite exponent whose leading term has a
-/// transfinite exponent itself (e.g., `2^(ω^ω·3)`). This case is not yet implemented.
+/// Panics when the base is finite (≥ 2) and the exponent is transfinite with
+/// a CNF term `ω^β · k` where `β` is itself transfinite. Examples:
+///
+/// - `2.pow(ω^ω · 3)`           - β = ω
+/// - `2.pow(ω^(ω+1))`           - β = ω+1
+/// - `2.pow(ω^ω + 5)`           - the leading term has β = ω
+///
+/// All other shapes are supported, including transfinite-base exponentiation
+/// like `ω.pow(ω^ω)` and finite-base with finite-tower exponents like
+/// `2.pow(ω^5 · 3)`. Implementation of the panicking case is tracked for a
+/// future release.
 impl Pow<Ordinal> for Ordinal {
     type Output = Self;
 

--- a/tests/comprehensive_tests.rs
+++ b/tests/comprehensive_tests.rs
@@ -739,4 +739,80 @@ mod integration_tests {
         assert!(ord1 < omega_omega);
         assert!(omega_omega < ord2);
     }
+
+    // ========================================
+    // FINITE-BASE TRANSFINITE-TOWER EXPONENTIATION
+    // ========================================
+    //
+    // Pre-0.3.0, raising a finite base ≥ 2 to an exponent containing a CNF
+    // term ω^β · v with β itself transfinite would hit a todo!() panic.
+    // The implementation rule, drawn from Carneiro's MathStackExchange answer
+    // (https://math.stackexchange.com/q/2588262) and Madore's reference Haskell
+    // code, is: for transfinite β, n^(ω^β · v) = ω^(ω^β · v) - the decrement
+    // present in the finite-β branch collapses because 1 + β = β.
+    //
+    // Verification strategy: each test computes 2^X via the new path and
+    // compares to ω^X computed via the existing transfinite-base path.
+    // Equality across these two independently derived expressions confirms
+    // the formula end-to-end.
+
+    #[test]
+    fn test_finite_pow_omega_to_omega() {
+        // 2^(ω^ω) = ω^(ω^ω)
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_omega = omega.clone().pow(omega.clone());
+        assert_eq!(two.pow(omega_omega.clone()), omega.pow(omega_omega));
+    }
+
+    #[test]
+    fn test_finite_pow_omega_omega_times_three() {
+        // 2^(ω^ω · 3) = ω^(ω^ω · 3) - the exact case the original review
+        // surfaced as the panicking input.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_omega = omega.clone().pow(omega.clone());
+        let exp = omega_omega * Ordinal::new_finite(3);
+        assert_eq!(two.pow(exp.clone()), omega.pow(exp));
+    }
+
+    #[test]
+    fn test_finite_pow_omega_to_omega_plus_one() {
+        // 2^(ω^(ω+1)) = ω^(ω^(ω+1)) - confirms "no decrement" is correct
+        // for transfinite successors, not only transfinite limits.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let exp = omega.clone().pow(omega.successor());
+        assert_eq!(two.pow(exp.clone()), omega.pow(exp));
+    }
+
+    #[test]
+    fn test_finite_pow_mixed_finite_transfinite_terms() {
+        // 2^(ω^ω + ω + 5) = ω^(ω^ω + 1) · 32
+        // Three CNF terms of three different types in the same exponent.
+        // Verifies the loop combines all three contribution types correctly:
+        //   ω^ω · 1   (transfinite e)  → ω^(ω^ω)
+        //   ω · 1     (e = 1)          → ω
+        //   5         (finite term)    → 2^5 = 32
+        // Then ω^(ω^ω) · ω = ω^(ω^ω + 1), and · 32 scales the multiplicity.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_omega = omega.clone().pow(omega.clone());
+        let exp = omega_omega.clone() + omega.clone() + Ordinal::new_finite(5);
+
+        let result = two.pow(exp);
+        let expected = omega.pow(omega_omega + Ordinal::one()) * Ordinal::new_finite(32);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_finite_pow_omega_squared_inner() {
+        // 2^(ω^(ω²)) = ω^(ω^(ω²)) - confirms the formula doesn't depend on
+        // the inner exponent being structurally simple.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_squared = omega.clone().pow(Ordinal::new_finite(2));
+        let exp = omega.clone().pow(omega_squared);
+        assert_eq!(two.pow(exp.clone()), omega.pow(exp));
+    }
 }


### PR DESCRIPTION
## Summary

Closes the only remaining `todo!()` in the Pow impl, replacing the
fallback panic on `2^(ω^ω · 3)`-shaped inputs with a real
implementation. Net effect: every documented Pow input now produces a
real ordinal.

## The math

For finite `n ≥ 2` and a CNF term `ω^e · k` in the exponent:

| `e` | Contribution to `n^(rhs)` |
|---|---|
| `0` (finite term) | `n^k` via `binary_pow` (already implemented) |
| finite `≥ 1` | `ω^(ω^(e-1) · k)` (already implemented) |
| **transfinite** | **`ω^(ω^e · k)`** - no decrement on `e` |

The "no decrement" branch is correct because `1 + e = e` for any
transfinite `e` (left absorption of finite into transfinite), so
`ω^(e-1)` and `ω^e` coincide on this path. Sources:

- Mario Carneiro on math.stackexchange.com (q/2588262, 2018)
- David Madore's `ordinal-arithmetic/Ordinal.hs` (`usualPower` helper)

## Changes

- `src/ordinal.rs` - replace the `todo!()` at the transfinite-`e`
  branch with a 3-line implementation parallel to the finite-`e`
  branch directly above it.
- `src/ordinal.rs` - drop the `# Panics` block from the Pow doc since
  the path no longer panics.
- `tests/comprehensive_tests.rs` - add five deterministic tests in a
  new section pinning the formula:
  - `test_finite_pow_omega_to_omega` (simplest case, `e = ω`)
  - `test_finite_pow_omega_omega_times_three` (the original review
    case)
  - `test_finite_pow_omega_to_omega_plus_one` (transfinite-successor
    inner exponent)
  - `test_finite_pow_mixed_finite_transfinite_terms` (three CNF term
    types in one exponent)
  - `test_finite_pow_omega_squared_inner` (non-trivial transfinite
    inner exponent)

## Supersedes

The earlier commit on this branch only sharpened the `# Panics` doc as
a documented fallback. This update replaces that fallback with the
actual implementation.

## Test plan

- [x] `cargo test` - 185 tests green (48 unit + 45 + 25 + 13 + 2
      integration + 52 doc)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean