### PR TITLE
Wave 6: Coverage for shared-leading comparison, deep display, saturation

### DIFF
--- a/tests/comprehensive_tests.rs
+++ b/tests/comprehensive_tests.rs
@@ -815,4 +815,88 @@ mod integration_tests {
         let exp = omega.clone().pow(omega_squared);
         assert_eq!(two.pow(exp.clone()), omega.pow(exp));
     }
+
+    // ========================================
+    // COMPARISON: SHARED LEADING TERM
+    // ========================================
+    //
+    // Existing comparison tests focus on different leading terms or different
+    // arity. These exercise the recursive lexicographic compare path where the
+    // leading term is identical and the difference lies further down the CNF.
+
+    #[test]
+    fn test_comparison_same_leading_term_differing_multiplicity() {
+        // ω² + ω vs ω² + ω·2 - same first two exponent layers, multiplicity differs.
+        let lhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .build()
+            .unwrap();
+        let rhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(2)
+            .build()
+            .unwrap();
+        assert!(lhs < rhs);
+        assert!(rhs > lhs);
+    }
+
+    #[test]
+    fn test_comparison_same_leading_term_finite_vs_omega_tail() {
+        // ω² + 5 vs ω² + ω - finite tail loses to any transfinite tail.
+        let lhs = Ordinal::builder().omega_power(2).plus(5).build().unwrap();
+        let rhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .build()
+            .unwrap();
+        assert!(lhs < rhs);
+    }
+
+    #[test]
+    fn test_comparison_same_leading_term_differing_finite_tail() {
+        // ω² + ω + 5 vs ω² + ω + 100 - everything matches except trailing finite.
+        let lhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .plus(5)
+            .build()
+            .unwrap();
+        let rhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .plus(100)
+            .build()
+            .unwrap();
+        assert!(lhs < rhs);
+    }
+
+    #[test]
+    fn test_comparison_same_leading_strict_prefix() {
+        // ω² < ω² + 1 - shared leading term, rhs has extra trailing term.
+        let lhs = Ordinal::builder().omega_power(2).build().unwrap();
+        let rhs = Ordinal::builder().omega_power(2).plus(1).build().unwrap();
+        assert!(lhs < rhs);
+    }
+
+    // ========================================
+    // DEEP EXPONENT DISPLAY
+    // ========================================
+
+    #[test]
+    fn test_deep_exponent_display() {
+        // ω^(ω^(ω+1)) - three nested levels exercise the recursive Display path.
+        let omega = Ordinal::omega();
+        let omega_plus_one = omega.successor();
+        let inner = omega.clone().pow(omega_plus_one);
+        let nested = omega.pow(inner);
+
+        let formatted = format!("{}", nested);
+
+        // Sanity: contains omega glyph and an exponent marker.
+        assert!(formatted.contains('ω'), "expected ω in: {formatted}");
+        assert!(formatted.contains('^'), "expected ^ in: {formatted}");
+        // The innermost ω+1 should still be visible.
+        assert!(formatted.contains("+ 1"), "expected '+ 1' in: {formatted}");
+    }
 }

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -341,3 +341,46 @@ fn test_reference_exponentiation() {
     assert_eq!((&two).pow(three.clone()), Ordinal::new_finite(8));
     assert_eq!(two.pow(three), Ordinal::new_finite(8));
 }
+
+// ========================================
+// SATURATING ARITHMETIC AT u32::MAX
+// ========================================
+//
+// Finite ordinal arithmetic is documented to saturate at u32::MAX rather than
+// panic on overflow. These tests pin the contract at the boundary so a future
+// switch to checked or wrapping arithmetic would fail loudly here.
+
+#[test]
+fn test_finite_pow_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    let two = Ordinal::new_finite(2);
+    assert_eq!(big.pow(two), Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_pow_large_exponent_saturates() {
+    // 2^32 already exceeds u32::MAX; 2^1000 must saturate.
+    let two = Ordinal::new_finite(2);
+    let thousand = Ordinal::new_finite(1000);
+    assert_eq!(two.pow(thousand), Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_mul_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    let two = Ordinal::new_finite(2);
+    assert_eq!(big * two, Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_add_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    let one = Ordinal::one();
+    assert_eq!(big + one, Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_successor_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    assert_eq!(big.successor(), Ordinal::new_finite(u32::MAX));
+}


### PR DESCRIPTION
## Summary
Plugs three test gaps identified in the 0.3.0 review.

### Comparison: shared leading CNF term (4 tests)
The existing comparison suite focused on different leading exponents or differing arity. These exercise the recursive lexicographic compare path where the leading term is identical:
- ω² + ω vs ω² + ω·2 (multiplicity differs at the same exponent layer)
- ω² + 5 vs ω² + ω (finite tail vs transfinite tail)
- ω² + ω + 5 vs ω² + ω + 100 (only trailing finite differs)
- ω² vs ω² + 1 (strict prefix)

### Deep exponent display (1 test)
Formats ω^(ω^(ω+1)) and confirms the recursive `Display` path produces a string with the expected components (ω glyph, ^ marker, "+ 1" innermost).

### Saturating arithmetic at u32::MAX (5 tests)
Pins the documented saturation contract for finite pow / mul / add / successor / pow-large-exponent. A future switch to checked or wrapping arithmetic would fail loudly here.

### Not added: property tests for transfinite-base exponentiation
Wave 5a (the implementation of finite^transfinite_tower) was deferred to 0.4.0; the proptest extension that was planned to cover it lands alongside that implementation.

## Test plan
- [x] `cargo test` - 190 tests pass (48 unit + 45+30+13+2 integration + 52 doc)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean (pre-commit ran it)
- [ ] CI green