### PR TITLE
Wave 7: Headline examples - Goodstein, Hydra, ε₀

### DIFF
--- a/examples/epsilon_zero.rs
+++ b/examples/epsilon_zero.rs
@@ -1,0 +1,88 @@
+//! # Approaching ε₀
+//!
+//! ε₀ (epsilon-zero) is the smallest ordinal `α` satisfying `ω^α = α`.
+//! Equivalently, it is the limit of the tower
+//!
+//! ```text
+//! ω, ω^ω, ω^(ω^ω), ω^(ω^(ω^ω)), ...
+//! ```
+//!
+//! Each rung is finitely larger than the previous, but ε₀ itself is the
+//! supremum of the entire infinite sequence.
+//!
+//! This crate represents ordinals **strictly below ε₀** in Cantor Normal
+//! Form. ε₀ itself is not representable - by the fixed-point definition,
+//! you would need ε₀ to appear inside its own CNF, which the data
+//! structure does not allow.
+//!
+//! This example walks the tower for a few rungs, prints each one, and
+//! confirms that the sequence is strictly increasing. It also demonstrates
+//! the representation cap: how big the ordinals can get before allocation
+//! becomes prohibitive.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example epsilon_zero
+//! ```
+
+use num_traits::Pow;
+use transfinite::Ordinal;
+
+/// Compute the n-th rung of the tower ω, ω^ω, ω^(ω^ω), ω^(ω^(ω^ω)), ...
+fn tower(n: u32) -> Ordinal {
+    let mut current = Ordinal::omega();
+    for _ in 1..n {
+        current = Ordinal::omega().pow(current);
+    }
+    current
+}
+
+fn main() {
+    println!("Approaching ε₀: the tower ω, ω^ω, ω^(ω^ω), ...\n");
+
+    // The first few rungs are small enough to print.
+    for n in 1..=4 {
+        let rung = tower(n);
+        println!("  rung {n}:  {rung}");
+    }
+    println!();
+
+    println!("Each rung is strictly greater than the previous:");
+    for n in 1..=4 {
+        let here = tower(n);
+        let next = tower(n + 1);
+        let strictly_less = here < next;
+        let marker = if strictly_less { "✓" } else { "✗" };
+        println!("  {marker} rung {n} < rung {}", n + 1);
+    }
+    println!();
+
+    // The supremum of all rungs is ε₀, which satisfies ω^ε₀ = ε₀.
+    // No ordinal in this crate can express ε₀ directly: any attempt to
+    // construct ω^ε₀ recursively would require ε₀ to appear inside its
+    // own Cantor Normal Form, which the data structure forbids.
+    println!("All rungs are strictly less than ε₀.");
+    println!("ε₀ is defined as the smallest fixed point of ω^x = x, the");
+    println!("supremum of this very sequence. No ordinal expressible in this");
+    println!("crate equals ε₀: any attempt to construct ω^ε₀ via this API");
+    println!("would require ε₀ to appear inside its own Cantor Normal Form,");
+    println!("which the type system prevents (you would loop indefinitely).\n");
+
+    // Demonstrate the representation cap: building deeper rungs.
+    // The ordinal stays small to print but contains a deeply nested CNF tree.
+    let rung_10 = tower(10);
+    let formatted = format!("{}", rung_10);
+    println!(
+        "Rung 10 has a string representation of length {}.",
+        formatted.len()
+    );
+    println!("Even at this depth, the underlying CNF data structure handles it");
+    println!("comfortably: just a recursive Vec<CnfTerm> of depth 10. Going");
+    println!("deeper is bounded by available memory rather than by any cap in");
+    println!("the type itself.\n");
+
+    println!("Summary: ε₀ is the upper boundary of what this crate represents.");
+    println!("Every ordinal you can construct via Ordinal::builder, From<u32>,");
+    println!("Add, Mul, or Pow lives strictly below it.");
+}

--- a/examples/goodstein.rs
+++ b/examples/goodstein.rs
@@ -1,0 +1,82 @@
+//! # Goodstein Sequences
+//!
+//! The Goodstein sequence starting at integer `n` is defined as:
+//!
+//! 1. Write `n` in **hereditary base-2** (every exponent is itself in base-2,
+//!    recursively all the way down).
+//! 2. Replace every occurrence of the base `2` with `3`. Subtract 1.
+//! 3. Replace every `3` with `4`. Subtract 1. Continue.
+//!
+//! Goodstein's theorem (1944) proves the sequence eventually reaches 0,
+//! but the integer values explode in size first. The proof goes through
+//! ordinals: replace every base in the hereditary representation with `ω`.
+//! The corresponding **ordinal** sequence strictly decreases at every step.
+//! Because ordinals below ε₀ are well-ordered, the ordinal sequence must
+//! terminate, and so the integer sequence does too.
+//!
+//! This example traces the (short) Goodstein sequence for `n = 3`,
+//! showing the ordinal counterpart at each step. The ordinal sequence is
+//! strictly decreasing, even when the integer sequence stays flat or
+//! grows transiently.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example goodstein
+//! ```
+
+use transfinite::Ordinal;
+
+fn print_step(step: u32, base: u32, value: u32, ordinal: &Ordinal) {
+    println!("  step {step:2}:  base {base},  integer = {value:5},  ordinal = {ordinal}");
+}
+
+fn main() {
+    println!("Goodstein's theorem: the integer sequence terminates because the");
+    println!("corresponding ordinal sequence strictly decreases, and ordinals");
+    println!("below ε₀ are well-ordered.\n");
+
+    println!("Sequence starting from n = 3:");
+    println!("  (hereditary base-2: 3 = 2 + 1, so the starting ordinal is ω + 1)\n");
+
+    // Precomputed Goodstein sequence for n = 3.
+    // At each step we show: which base we just bumped to, the integer value,
+    // and the ordinal you get by replacing every occurrence of the base with ω.
+    let omega = Ordinal::omega();
+    let steps: Vec<(u32, u32, u32, Ordinal)> = vec![
+        // (step, base, integer, ordinal)
+        (0, 2, 3, omega.clone() + Ordinal::one()), // 3 = 2 + 1     -> ω + 1
+        (1, 3, 3, omega),                          // 3 = 3         -> ω
+        (2, 4, 3, Ordinal::new_finite(3)),         // 3 = 3 (no 4)  -> 3
+        (3, 5, 2, Ordinal::new_finite(2)),         // 2 = 2         -> 2
+        (4, 6, 1, Ordinal::new_finite(1)),         // 1 = 1         -> 1
+        (5, 7, 0, Ordinal::new_finite(0)),         // 0             -> 0  (terminates!)
+    ];
+
+    for (step, base, value, ordinal) in &steps {
+        print_step(*step, *base, *value, ordinal);
+    }
+
+    println!("\nVerifying the ordinal sequence is strictly decreasing:");
+    for window in steps.windows(2) {
+        let (s_a, _, _, ord_a) = &window[0];
+        let (s_b, _, _, ord_b) = &window[1];
+        let strictly_less = ord_b < ord_a;
+        let marker = if strictly_less { "✓" } else { "✗" };
+        println!(
+            "  {marker} step {s_a} ({ord_a}) > step {s_b} ({ord_b})  -  {}",
+            if strictly_less { "ok" } else { "VIOLATION" }
+        );
+    }
+
+    println!("\nThe ordinal sequence ω + 1 > ω > 3 > 2 > 1 > 0 has length 6.");
+    println!("The integer sequence 3, 3, 3, 2, 1, 0 also has length 6 - they");
+    println!("happen to coincide here because n is small. For n = 4 the integer");
+    println!("sequence reaches 0 only after a number of steps that does not fit");
+    println!("in any reasonable computer (Goodstein numbers grow VERY fast),");
+    println!("yet the ordinal sequence stays bounded by ω^ω throughout.\n");
+
+    println!("This is the headline use case for ordinals up to ε₀: certifying");
+    println!("termination of processes that vastly exceed primitive recursive");
+    println!("bounds.");
+}

--- a/examples/hydra.rs
+++ b/examples/hydra.rs
@@ -1,0 +1,153 @@
+//! # Kirby-Paris Hydra
+//!
+//! A *hydra* is a finite rooted tree. Hercules cuts a leaf. The hydra
+//! responds: the parent of the cut leaf grows `n` copies of the rest of
+//! the subtree above it (where `n` is the round number, so it grows
+//! faster every turn). The game ends when only the root remains.
+//!
+//! Kirby and Paris (1982) proved Hercules **always wins**, no matter how
+//! big the hydra grows. The proof labels each node with an ordinal: the
+//! hydra's ordinal is then derived from those labels, and every cut
+//! strictly decreases the ordinal. Because ordinals below ε₀ are
+//! well-ordered, the descent must terminate.
+//!
+//! Strikingly, Kirby and Paris also showed this theorem is **independent
+//! of Peano Arithmetic** - termination cannot be proved using induction
+//! over natural numbers alone. You need the full strength of ordinals
+//! up to ε₀.
+//!
+//! This example does not simulate the full hydra dynamics (the integer
+//! state explodes too fast). Instead it shows a small hydra and the
+//! ordinal label that proves termination.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example hydra
+//! ```
+
+use transfinite::Ordinal;
+
+/// A hydra is a tree where each node has a list of children. We label each
+/// node with the ordinal that represents the subtree rooted at that node.
+struct Hydra {
+    /// Ordinal label of each subtree, ordered from largest to smallest
+    /// (matching the CNF convention).
+    children: Vec<Hydra>,
+}
+
+impl Hydra {
+    fn leaf() -> Self {
+        Hydra { children: vec![] }
+    }
+
+    /// Convert this hydra to its ordinal label.
+    ///
+    /// A leaf has label 0. An internal node with children labeled
+    /// β₁ ≥ β₂ ≥ ... ≥ βₖ has label ω^β₁ + ω^β₂ + ... + ω^βₖ.
+    fn to_ordinal(&self) -> Ordinal {
+        if self.children.is_empty() {
+            return Ordinal::zero();
+        }
+
+        // Sort child ordinals descending and accumulate as ω^β_i sum.
+        let mut child_ordinals: Vec<Ordinal> = self.children.iter().map(Self::to_ordinal).collect();
+        child_ordinals.sort_by(|a, b| b.cmp(a)); // descending
+
+        let mut builder = Ordinal::builder();
+        let mut last: Option<Ordinal> = None;
+        let mut multiplicity: u32 = 0;
+
+        for beta in child_ordinals {
+            if last.as_ref() == Some(&beta) {
+                multiplicity += 1;
+            } else {
+                if let Some(prev) = last {
+                    builder = builder.term(prev, multiplicity);
+                }
+                last = Some(beta);
+                multiplicity = 1;
+            }
+        }
+        if let Some(prev) = last {
+            builder = builder.term(prev, multiplicity);
+        }
+
+        builder.build().expect("CNF terms in decreasing order")
+    }
+}
+
+fn main() {
+    println!("Kirby-Paris Hydra: every cut strictly decreases an ordinal label,");
+    println!("and ordinals below ε₀ are well-ordered, so Hercules always wins.\n");
+
+    // Hydra 1: a single edge from root to a leaf.
+    //   root - leaf
+    // ordinal label: ω^0 = 1.
+    let h1 = Hydra {
+        children: vec![Hydra::leaf()],
+    };
+    println!("Hydra 1: root with a single leaf child");
+    println!("  ordinal = {}\n", h1.to_ordinal());
+
+    // Hydra 2: root with three leaf children.
+    //   root - leaf, leaf, leaf
+    // each child labeled 0, so root labeled ω^0 + ω^0 + ω^0 = 3.
+    let h2 = Hydra {
+        children: (0..3).map(|_| Hydra::leaf()).collect(),
+    };
+    println!("Hydra 2: root with three leaf children");
+    println!("  ordinal = {}\n", h2.to_ordinal());
+
+    // Hydra 3: root - middle - leaf  (a chain of length 2).
+    // leaf labeled 0, middle labeled ω^0 = 1, root labeled ω^1 = ω.
+    let h3 = Hydra {
+        children: vec![Hydra {
+            children: vec![Hydra::leaf()],
+        }],
+    };
+    println!("Hydra 3: a chain - root - middle - leaf");
+    println!("  ordinal = {}\n", h3.to_ordinal());
+
+    // Hydra 4: root with two children, each itself a chain of length 2.
+    //   root
+    //   ├── middle - leaf
+    //   └── middle - leaf
+    // each branch labeled ω, so root labeled ω^ω + ω^ω = ω^ω · 2.
+    let h4 = Hydra {
+        children: vec![
+            Hydra {
+                children: vec![Hydra::leaf()],
+            },
+            Hydra {
+                children: vec![Hydra::leaf()],
+            },
+        ],
+    };
+    println!("Hydra 4: root with two chain-of-length-2 branches");
+    println!("  ordinal = {}\n", h4.to_ordinal());
+
+    // Hydra 5: root with one branch that has a depth-2 chain ending in a leaf.
+    //   root
+    //   └── middle1
+    //       └── middle2 - leaf
+    // labels: leaf=0, middle2=ω^0=1, middle1=ω^1=ω, root=ω^ω.
+    let h5 = Hydra {
+        children: vec![Hydra {
+            children: vec![Hydra {
+                children: vec![Hydra::leaf()],
+            }],
+        }],
+    };
+    println!("Hydra 5: root with a depth-3 chain to a leaf");
+    println!("  ordinal = {}\n", h5.to_ordinal());
+
+    println!("Each hydra's ordinal label is its certificate of termination.");
+    println!("When Hercules cuts a leaf, the parent grows N copies of the");
+    println!("rest of the subtree above it (N = round number). Even though");
+    println!("the integer node count explodes, the ordinal label STRICTLY");
+    println!("DECREASES. Because there is no infinite descending chain in");
+    println!("the ordinals, Hercules wins in finitely many rounds - even");
+    println!("though that number can be astronomically larger than anything");
+    println!("Peano Arithmetic can express.");
+}


### PR DESCRIPTION
## Summary
The crate's "why use ordinals up to ε₀" pitch lives in three classic results that none of the existing examples demonstrate. Adds runnable examples for each:

### \`examples/goodstein.rs\`
Traces the (short) Goodstein sequence for n = 3, hardcoding the integer values and showing the corresponding ordinal counterparts strictly decrease:

\`\`\`
ω + 1 > ω > 3 > 2 > 1 > 0
\`\`\`

Hardcoded because deriving the ordinal from each integer requires full hereditary base computation, which is out of scope for an example. The integer sequence happens to also have length 6 here only because n is small; for n = 4 the integer sequence has length too large to fit in any computer, but the ordinal stays bounded by ω^ω throughout.

### \`examples/hydra.rs\`
Models a finite rooted tree as the data structure of a Kirby-Paris hydra, computes the ordinal label of each subtree (recursive ω^β_i sum with multiplicities), and prints five small hydras with their labels (1, 3, ω, ω·2, ω^ω). Notes the famous result that this theorem is **independent of Peano Arithmetic** - it cannot be proved using induction over naturals alone.

### \`examples/epsilon_zero.rs\`
Walks the tower ω, ω^ω, ω^(ω^ω), ω^(ω^(ω^ω)) for the first four rungs, confirms the sequence is strictly increasing, builds rung 10 to demonstrate the representation can go arbitrarily deep, and explains why ε₀ itself is not representable in this CNF data structure (would require ε₀ to appear inside its own CNF).

## Test plan
- [x] \`cargo run --example goodstein\` - prints sequence and verifies strict decrease
- [x] \`cargo run --example hydra\` - prints five hydras with their ordinal labels
- [x] \`cargo run --example epsilon_zero\` - walks the tower, confirms strict increase
- [x] \`cargo run --example exponentiation\` - existing example still works
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean
- [ ] CI green