### PR TITLE
Wave 8: OIDC trusted publishing for crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,13 @@ jobs:
     name: Publish
     needs: ci
     runs-on: ubuntu-latest
+    # OIDC trusted publishing requires id-token: write so the workflow can
+    # request an OIDC token that crates.io exchanges for a short-lived
+    # publish token. contents: read is the implicit default but stated here
+    # explicitly so the principle of least privilege is visible.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -31,7 +38,11 @@ jobs:
             exit 1
           fi
 
+      - name: Authenticate to crates.io via OIDC
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish --locked
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary
Replaces the long-lived \`CARGO_REGISTRY_TOKEN\` secret with short-lived OIDC-issued tokens via \`rust-lang/crates-io-auth-action\`. This removes the secret from the blast radius if the repo or a workflow is ever compromised: the OIDC token is scoped to this exact workflow on this exact repo and expires within minutes.

Also folds in the \`--locked\` flag from Wave 1 (whichever PR merges first, the other becomes a no-op for the locked change).

## ⚠️ MANUAL STEP REQUIRED before this can ship

Configure the trusted publisher on crates.io BEFORE merging this PR. Without it, the next tag push will fail to authenticate.

1. Go to https://crates.io/crates/transfinite/settings/publishers
2. Add a GitHub trusted publisher with:
   - **Owner:** \`niarenaw\`
   - **Repository:** \`rust-transfinite\`
   - **Workflow:** \`publish.yml\`
   - **Environment:** *(blank)*

After the first successful OIDC publish, the \`CARGO_REGISTRY_TOKEN\` repo secret should be deleted (it will no longer be needed).

## Diff

- Add \`permissions: id-token: write\` so the workflow can request an OIDC token
- Add \`rust-lang/crates-io-auth-action@v1\` step that exchanges OIDC token for a short-lived registry token
- Switch the publish step's env to use the action's output instead of the secret
- Add \`--locked\` (Wave 1 overlap)

## References
- [crates.io trusted publishing docs](https://crates.io/docs/trusted-publishing)
- [rust-lang/crates-io-auth-action](https://github.com/rust-lang/crates-io-auth-action)

## Test plan
- [ ] Manual crates.io configuration completed (see above)
- [ ] Workflow file parses (GitHub Actions will validate on merge)
- [ ] Real verification happens at v0.3.0 tag push - if this fails, can roll back to the previous workflow before re-tagging