### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,13 @@ jobs:
     name: Publish
     needs: ci
     runs-on: ubuntu-latest
+    # OIDC trusted publishing requires id-token: write so the workflow can
+    # request an OIDC token that crates.io exchanges for a short-lived
+    # publish token. contents: read is the implicit default but stated here
+    # explicitly so the principle of least privilege is visible.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -31,7 +38,11 @@ jobs:
             exit 1
           fi
 
+      - name: Authenticate to crates.io via OIDC
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Publish to crates.io
         run: cargo publish --locked
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,6 @@ jobs:
           fi
 
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial public release with ordinal arithmetic up to ε₀.
+
+[0.2.2]: https://github.com/niarenaw/rust-transfinite/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/niarenaw/rust-transfinite/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/niarenaw/rust-transfinite/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-28
+
+### Added
+
+- `impl num_traits::Zero` and `impl num_traits::One` for `Ordinal`, enabling
+  use in generic contexts that require those traits.
+- Inherent `Ordinal::is_zero()`, callable without bringing `num_traits::Zero`
+  into scope.
+- `Ordinal::leading_cnf_term_ref()` and `Ordinal::trailing_cnf_term_ref()`
+  for borrow-only inspection of CNF terms (avoid the clone in the existing
+  `leading_cnf_term()` / `trailing_cnf_term()` accessors).
+- `Ordinal::cnf_terms_iter()` returning a `slice::Iter<'_, CnfTerm>` so
+  callers can iterate without allocating.
+- `Ordinal::zero()` and `Ordinal::one()` are now `const fn`.
+- `# Examples` section on `OrdinalBuilder::term` matching the style used by
+  `omega_power` and `plus`.
+- Keep-a-Changelog comparison links footer.
+- Three runnable examples under `examples/`: `goodstein`, `hydra`, and
+  `epsilon_zero`, each showing how ordinal well-ordering proves termination
+  of a process whose integer behavior grows enormously.
+- Criterion benchmark suite (`benches/ordinal_bench.rs`) covering binary
+  exponentiation, multiplication chains, builder construction, addition,
+  ordinal exponentiation, and successor on multi-term CNFs. Run with
+  `cargo bench`.
+- Test coverage for shared-leading-term comparison (recursive lex compare),
+  deeply nested exponent display, and saturating finite arithmetic at
+  `u32::MAX`.
+
+### Changed
+
+- Finite-base exponentiation with a transfinite-tower exponent
+  (`n^(ω^β · k)` where `β` itself is transfinite, e.g. `2^(ω^ω · 3)`) is
+  now fully implemented. Previously this path hit a `todo!()` panic. The
+  rule applied is `n^(ω^β · k) = ω^(ω^β · k)` for transfinite `β`, drawn
+  from Mario Carneiro's [math.stackexchange answer][carneiro] and David
+  Madore's reference Haskell implementation.
+
+[carneiro]: https://math.stackexchange.com/q/2588262
+
+### Breaking
+
+- `OrdinalError` is now `#[non_exhaustive]`. Exhaustive `match` arms over
+  this enum will need a wildcard arm. This is a deliberate contract change
+  so future error variants can be added without bumping the major version.
+
+### Internal
+
+- `cargo publish` in the release workflow now uses `--locked` to ensure the
+  published artifact is built from the committed `Cargo.lock`.
+- The publish workflow now uses crates.io trusted publishing (OIDC) instead
+  of a long-lived `CARGO_REGISTRY_TOKEN` secret.
+- The `Security Audit` CI job has explicit `checks: write` permission so its
+  result-reporting step no longer fails on `release/*` push events.
+
 ## [0.2.2] - 2026-02-08
 
 ### Added
@@ -51,6 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release with ordinal arithmetic up to ε₀.
 
+[Unreleased]: https://github.com/niarenaw/rust-transfinite/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/niarenaw/rust-transfinite/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/niarenaw/rust-transfinite/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/niarenaw/rust-transfinite/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/niarenaw/rust-transfinite/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "transfinite"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "cargo-husky",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,32 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +51,21 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cargo-husky"
@@ -36,10 +74,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
@@ -76,6 +241,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +318,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-traits"
@@ -101,6 +339,46 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -128,7 +406,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -199,6 +477,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,12 +531,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -227,6 +554,58 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -254,6 +633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,10 +659,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "transfinite"
 version = "0.2.2"
 dependencies = [
  "cargo-husky",
+ "criterion",
  "num-traits",
  "proptest",
  "thiserror",
@@ -305,6 +701,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +718,92 @@ checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -353,3 +845,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/niarenaw/rust-transfinite"
 keywords = ["ordinal", "transfinite", "mathematics", "cantor", "ordinal-arithmetic"]
 categories = ["mathematics", "algorithms"]
 rust-version = "1.81"
+exclude = ["**/CLAUDE.md", ".github/"]
 
 [dependencies]
 num-traits = "0.2.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfinite"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["niarenaw"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,12 @@ thiserror = "2.0.11"
 
 [dev-dependencies]
 proptest = "1.4"
+criterion = "0.4"
 cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"] }
+
+[[bench]]
+name = "ordinal_bench"
+harness = false
 
 [lints.rust]
 future-incompatible = "warn"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-transfinite = "0.2.1"
+transfinite = "0.3.0"
 ```
 
 ### Basic Example

--- a/benches/ordinal_bench.rs
+++ b/benches/ordinal_bench.rs
@@ -1,0 +1,124 @@
+//! Performance baselines for `Ordinal` arithmetic.
+//!
+//! These benches exist primarily to detect regressions when refactoring the
+//! arithmetic hot paths (clone reduction, trait impl restructuring, and the
+//! eventual `finite^transfinite_tower` implementation). Run with:
+//!
+//! ```text
+//! cargo bench --bench ordinal_bench
+//! ```
+//!
+//! To establish a named baseline before a refactor:
+//!
+//! ```text
+//! cargo bench --bench ordinal_bench -- --save-baseline pre-refactor
+//! ```
+//!
+//! And to compare after:
+//!
+//! ```text
+//! cargo bench --bench ordinal_bench -- --baseline pre-refactor
+//! ```
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use num_traits::Pow;
+use transfinite::{CnfTerm, Ordinal};
+
+fn bench_pow_finite_exponent(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pow_omega_to_finite_exponent");
+    let omega = Ordinal::omega();
+    for exp in [10u32, 100, 1000] {
+        group.bench_with_input(BenchmarkId::from_parameter(exp), &exp, |b, &exp| {
+            b.iter(|| {
+                let result = black_box(omega.clone()).pow(black_box(Ordinal::new_finite(exp)));
+                black_box(result)
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_pow_transfinite_exponent(c: &mut Criterion) {
+    let omega = Ordinal::omega();
+    let omega_plus_one = omega.successor();
+
+    c.bench_function("pow_omega_to_omega", |b| {
+        b.iter(|| black_box(omega.clone()).pow(black_box(omega.clone())))
+    });
+
+    c.bench_function("pow_omega_to_omega_plus_one", |b| {
+        b.iter(|| black_box(omega.clone()).pow(black_box(omega_plus_one.clone())))
+    });
+}
+
+fn bench_multiplication_chain(c: &mut Criterion) {
+    // (ω + 1) chained 100 times via repeated multiplication.
+    let omega_plus_one = Ordinal::omega().successor();
+
+    c.bench_function("multiplication_chain_100", |b| {
+        b.iter(|| {
+            let mut acc = Ordinal::one();
+            for _ in 0..100 {
+                acc = acc * black_box(omega_plus_one.clone());
+            }
+            black_box(acc)
+        });
+    });
+}
+
+fn bench_addition(c: &mut Criterion) {
+    // (ω² + ω + 1) + (ω² + ω + 1) - exercises the merge path.
+    let lhs = Ordinal::builder()
+        .omega_power(2)
+        .omega_times(1)
+        .plus(1)
+        .build()
+        .unwrap();
+    let rhs = lhs.clone();
+
+    c.bench_function("add_three_term_to_three_term", |b| {
+        b.iter(|| black_box(lhs.clone()) + black_box(rhs.clone()))
+    });
+}
+
+fn bench_construction_five_term(c: &mut Criterion) {
+    // Construct ω⁴ + ω³ + ω² + ω + 42 via the builder.
+    c.bench_function("build_five_term_cnf", |b| {
+        b.iter(|| {
+            Ordinal::builder()
+                .omega_power(4)
+                .omega_power(3)
+                .omega_power(2)
+                .omega_times(1)
+                .plus(42)
+                .build()
+                .unwrap()
+        });
+    });
+}
+
+fn bench_successor_three_term(c: &mut Criterion) {
+    // successor() on ω² + ω·3 + 7. Trailing term is finite, so this exercises
+    // the in-place increment path (Wave 5c will optimize this).
+    let three_term = Ordinal::new_transfinite(&[
+        CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap(),
+        CnfTerm::new(&Ordinal::one(), 3).unwrap(),
+        CnfTerm::new_finite(7),
+    ])
+    .unwrap();
+
+    c.bench_function("successor_three_term_finite_trailing", |b| {
+        b.iter(|| black_box(&three_term).successor())
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_pow_finite_exponent,
+    bench_pow_transfinite_exponent,
+    bench_multiplication_chain,
+    bench_addition,
+    bench_construction_five_term,
+    bench_successor_three_term,
+);
+criterion_main!(benches);

--- a/examples/epsilon_zero.rs
+++ b/examples/epsilon_zero.rs
@@ -1,0 +1,88 @@
+//! # Approaching ε₀
+//!
+//! ε₀ (epsilon-zero) is the smallest ordinal `α` satisfying `ω^α = α`.
+//! Equivalently, it is the limit of the tower
+//!
+//! ```text
+//! ω, ω^ω, ω^(ω^ω), ω^(ω^(ω^ω)), ...
+//! ```
+//!
+//! Each rung is finitely larger than the previous, but ε₀ itself is the
+//! supremum of the entire infinite sequence.
+//!
+//! This crate represents ordinals **strictly below ε₀** in Cantor Normal
+//! Form. ε₀ itself is not representable - by the fixed-point definition,
+//! you would need ε₀ to appear inside its own CNF, which the data
+//! structure does not allow.
+//!
+//! This example walks the tower for a few rungs, prints each one, and
+//! confirms that the sequence is strictly increasing. It also demonstrates
+//! the representation cap: how big the ordinals can get before allocation
+//! becomes prohibitive.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example epsilon_zero
+//! ```
+
+use num_traits::Pow;
+use transfinite::Ordinal;
+
+/// Compute the n-th rung of the tower ω, ω^ω, ω^(ω^ω), ω^(ω^(ω^ω)), ...
+fn tower(n: u32) -> Ordinal {
+    let mut current = Ordinal::omega();
+    for _ in 1..n {
+        current = Ordinal::omega().pow(current);
+    }
+    current
+}
+
+fn main() {
+    println!("Approaching ε₀: the tower ω, ω^ω, ω^(ω^ω), ...\n");
+
+    // The first few rungs are small enough to print.
+    for n in 1..=4 {
+        let rung = tower(n);
+        println!("  rung {n}:  {rung}");
+    }
+    println!();
+
+    println!("Each rung is strictly greater than the previous:");
+    for n in 1..=4 {
+        let here = tower(n);
+        let next = tower(n + 1);
+        let strictly_less = here < next;
+        let marker = if strictly_less { "✓" } else { "✗" };
+        println!("  {marker} rung {n} < rung {}", n + 1);
+    }
+    println!();
+
+    // The supremum of all rungs is ε₀, which satisfies ω^ε₀ = ε₀.
+    // No ordinal in this crate can express ε₀ directly: any attempt to
+    // construct ω^ε₀ recursively would require ε₀ to appear inside its
+    // own Cantor Normal Form, which the data structure forbids.
+    println!("All rungs are strictly less than ε₀.");
+    println!("ε₀ is defined as the smallest fixed point of ω^x = x, the");
+    println!("supremum of this very sequence. No ordinal expressible in this");
+    println!("crate equals ε₀: any attempt to construct ω^ε₀ via this API");
+    println!("would require ε₀ to appear inside its own Cantor Normal Form,");
+    println!("which the type system prevents (you would loop indefinitely).\n");
+
+    // Demonstrate the representation cap: building deeper rungs.
+    // The ordinal stays small to print but contains a deeply nested CNF tree.
+    let rung_10 = tower(10);
+    let formatted = format!("{}", rung_10);
+    println!(
+        "Rung 10 has a string representation of length {}.",
+        formatted.len()
+    );
+    println!("Even at this depth, the underlying CNF data structure handles it");
+    println!("comfortably: just a recursive Vec<CnfTerm> of depth 10. Going");
+    println!("deeper is bounded by available memory rather than by any cap in");
+    println!("the type itself.\n");
+
+    println!("Summary: ε₀ is the upper boundary of what this crate represents.");
+    println!("Every ordinal you can construct via Ordinal::builder, From<u32>,");
+    println!("Add, Mul, or Pow lives strictly below it.");
+}

--- a/examples/goodstein.rs
+++ b/examples/goodstein.rs
@@ -1,0 +1,82 @@
+//! # Goodstein Sequences
+//!
+//! The Goodstein sequence starting at integer `n` is defined as:
+//!
+//! 1. Write `n` in **hereditary base-2** (every exponent is itself in base-2,
+//!    recursively all the way down).
+//! 2. Replace every occurrence of the base `2` with `3`. Subtract 1.
+//! 3. Replace every `3` with `4`. Subtract 1. Continue.
+//!
+//! Goodstein's theorem (1944) proves the sequence eventually reaches 0,
+//! but the integer values explode in size first. The proof goes through
+//! ordinals: replace every base in the hereditary representation with `ω`.
+//! The corresponding **ordinal** sequence strictly decreases at every step.
+//! Because ordinals below ε₀ are well-ordered, the ordinal sequence must
+//! terminate, and so the integer sequence does too.
+//!
+//! This example traces the (short) Goodstein sequence for `n = 3`,
+//! showing the ordinal counterpart at each step. The ordinal sequence is
+//! strictly decreasing, even when the integer sequence stays flat or
+//! grows transiently.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example goodstein
+//! ```
+
+use transfinite::Ordinal;
+
+fn print_step(step: u32, base: u32, value: u32, ordinal: &Ordinal) {
+    println!("  step {step:2}:  base {base},  integer = {value:5},  ordinal = {ordinal}");
+}
+
+fn main() {
+    println!("Goodstein's theorem: the integer sequence terminates because the");
+    println!("corresponding ordinal sequence strictly decreases, and ordinals");
+    println!("below ε₀ are well-ordered.\n");
+
+    println!("Sequence starting from n = 3:");
+    println!("  (hereditary base-2: 3 = 2 + 1, so the starting ordinal is ω + 1)\n");
+
+    // Precomputed Goodstein sequence for n = 3.
+    // At each step we show: which base we just bumped to, the integer value,
+    // and the ordinal you get by replacing every occurrence of the base with ω.
+    let omega = Ordinal::omega();
+    let steps: Vec<(u32, u32, u32, Ordinal)> = vec![
+        // (step, base, integer, ordinal)
+        (0, 2, 3, omega.clone() + Ordinal::one()), // 3 = 2 + 1     -> ω + 1
+        (1, 3, 3, omega),                          // 3 = 3         -> ω
+        (2, 4, 3, Ordinal::new_finite(3)),         // 3 = 3 (no 4)  -> 3
+        (3, 5, 2, Ordinal::new_finite(2)),         // 2 = 2         -> 2
+        (4, 6, 1, Ordinal::new_finite(1)),         // 1 = 1         -> 1
+        (5, 7, 0, Ordinal::new_finite(0)),         // 0             -> 0  (terminates!)
+    ];
+
+    for (step, base, value, ordinal) in &steps {
+        print_step(*step, *base, *value, ordinal);
+    }
+
+    println!("\nVerifying the ordinal sequence is strictly decreasing:");
+    for window in steps.windows(2) {
+        let (s_a, _, _, ord_a) = &window[0];
+        let (s_b, _, _, ord_b) = &window[1];
+        let strictly_less = ord_b < ord_a;
+        let marker = if strictly_less { "✓" } else { "✗" };
+        println!(
+            "  {marker} step {s_a} ({ord_a}) > step {s_b} ({ord_b})  -  {}",
+            if strictly_less { "ok" } else { "VIOLATION" }
+        );
+    }
+
+    println!("\nThe ordinal sequence ω + 1 > ω > 3 > 2 > 1 > 0 has length 6.");
+    println!("The integer sequence 3, 3, 3, 2, 1, 0 also has length 6 - they");
+    println!("happen to coincide here because n is small. For n = 4 the integer");
+    println!("sequence reaches 0 only after a number of steps that does not fit");
+    println!("in any reasonable computer (Goodstein numbers grow VERY fast),");
+    println!("yet the ordinal sequence stays bounded by ω^ω throughout.\n");
+
+    println!("This is the headline use case for ordinals up to ε₀: certifying");
+    println!("termination of processes that vastly exceed primitive recursive");
+    println!("bounds.");
+}

--- a/examples/hydra.rs
+++ b/examples/hydra.rs
@@ -1,0 +1,153 @@
+//! # Kirby-Paris Hydra
+//!
+//! A *hydra* is a finite rooted tree. Hercules cuts a leaf. The hydra
+//! responds: the parent of the cut leaf grows `n` copies of the rest of
+//! the subtree above it (where `n` is the round number, so it grows
+//! faster every turn). The game ends when only the root remains.
+//!
+//! Kirby and Paris (1982) proved Hercules **always wins**, no matter how
+//! big the hydra grows. The proof labels each node with an ordinal: the
+//! hydra's ordinal is then derived from those labels, and every cut
+//! strictly decreases the ordinal. Because ordinals below ε₀ are
+//! well-ordered, the descent must terminate.
+//!
+//! Strikingly, Kirby and Paris also showed this theorem is **independent
+//! of Peano Arithmetic** - termination cannot be proved using induction
+//! over natural numbers alone. You need the full strength of ordinals
+//! up to ε₀.
+//!
+//! This example does not simulate the full hydra dynamics (the integer
+//! state explodes too fast). Instead it shows a small hydra and the
+//! ordinal label that proves termination.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example hydra
+//! ```
+
+use transfinite::Ordinal;
+
+/// A hydra is a tree where each node has a list of children. We label each
+/// node with the ordinal that represents the subtree rooted at that node.
+struct Hydra {
+    /// Ordinal label of each subtree, ordered from largest to smallest
+    /// (matching the CNF convention).
+    children: Vec<Hydra>,
+}
+
+impl Hydra {
+    fn leaf() -> Self {
+        Hydra { children: vec![] }
+    }
+
+    /// Convert this hydra to its ordinal label.
+    ///
+    /// A leaf has label 0. An internal node with children labeled
+    /// β₁ ≥ β₂ ≥ ... ≥ βₖ has label ω^β₁ + ω^β₂ + ... + ω^βₖ.
+    fn to_ordinal(&self) -> Ordinal {
+        if self.children.is_empty() {
+            return Ordinal::zero();
+        }
+
+        // Sort child ordinals descending and accumulate as ω^β_i sum.
+        let mut child_ordinals: Vec<Ordinal> = self.children.iter().map(Self::to_ordinal).collect();
+        child_ordinals.sort_by(|a, b| b.cmp(a)); // descending
+
+        let mut builder = Ordinal::builder();
+        let mut last: Option<Ordinal> = None;
+        let mut multiplicity: u32 = 0;
+
+        for beta in child_ordinals {
+            if last.as_ref() == Some(&beta) {
+                multiplicity += 1;
+            } else {
+                if let Some(prev) = last {
+                    builder = builder.term(prev, multiplicity);
+                }
+                last = Some(beta);
+                multiplicity = 1;
+            }
+        }
+        if let Some(prev) = last {
+            builder = builder.term(prev, multiplicity);
+        }
+
+        builder.build().expect("CNF terms in decreasing order")
+    }
+}
+
+fn main() {
+    println!("Kirby-Paris Hydra: every cut strictly decreases an ordinal label,");
+    println!("and ordinals below ε₀ are well-ordered, so Hercules always wins.\n");
+
+    // Hydra 1: a single edge from root to a leaf.
+    //   root - leaf
+    // ordinal label: ω^0 = 1.
+    let h1 = Hydra {
+        children: vec![Hydra::leaf()],
+    };
+    println!("Hydra 1: root with a single leaf child");
+    println!("  ordinal = {}\n", h1.to_ordinal());
+
+    // Hydra 2: root with three leaf children.
+    //   root - leaf, leaf, leaf
+    // each child labeled 0, so root labeled ω^0 + ω^0 + ω^0 = 3.
+    let h2 = Hydra {
+        children: (0..3).map(|_| Hydra::leaf()).collect(),
+    };
+    println!("Hydra 2: root with three leaf children");
+    println!("  ordinal = {}\n", h2.to_ordinal());
+
+    // Hydra 3: root - middle - leaf  (a chain of length 2).
+    // leaf labeled 0, middle labeled ω^0 = 1, root labeled ω^1 = ω.
+    let h3 = Hydra {
+        children: vec![Hydra {
+            children: vec![Hydra::leaf()],
+        }],
+    };
+    println!("Hydra 3: a chain - root - middle - leaf");
+    println!("  ordinal = {}\n", h3.to_ordinal());
+
+    // Hydra 4: root with two children, each itself a chain of length 2.
+    //   root
+    //   ├── middle - leaf
+    //   └── middle - leaf
+    // each branch labeled ω, so root labeled ω^ω + ω^ω = ω^ω · 2.
+    let h4 = Hydra {
+        children: vec![
+            Hydra {
+                children: vec![Hydra::leaf()],
+            },
+            Hydra {
+                children: vec![Hydra::leaf()],
+            },
+        ],
+    };
+    println!("Hydra 4: root with two chain-of-length-2 branches");
+    println!("  ordinal = {}\n", h4.to_ordinal());
+
+    // Hydra 5: root with one branch that has a depth-2 chain ending in a leaf.
+    //   root
+    //   └── middle1
+    //       └── middle2 - leaf
+    // labels: leaf=0, middle2=ω^0=1, middle1=ω^1=ω, root=ω^ω.
+    let h5 = Hydra {
+        children: vec![Hydra {
+            children: vec![Hydra {
+                children: vec![Hydra::leaf()],
+            }],
+        }],
+    };
+    println!("Hydra 5: root with a depth-3 chain to a leaf");
+    println!("  ordinal = {}\n", h5.to_ordinal());
+
+    println!("Each hydra's ordinal label is its certificate of termination.");
+    println!("When Hercules cuts a leaf, the parent grows N copies of the");
+    println!("rest of the subtree above it (N = round number). Even though");
+    println!("the integer node count explodes, the ordinal label STRICTLY");
+    println!("DECREASES. Because there is no infinite descending chain in");
+    println!("the ordinals, Hercules wins in finitely many rounds - even");
+    println!("though that number can be astronomically larger than anything");
+    println!("Peano Arithmetic can express.");
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -48,8 +48,29 @@ impl OrdinalBuilder {
 
     /// Adds a CNF term with the given exponent and multiplicity.
     ///
-    /// Terms must be added in strictly decreasing exponent order.
-    /// If a term violates ordering or has zero multiplicity, an error is stored.
+    /// This is the lowest-level builder method; the convenience methods (`omega`,
+    /// `omega_power`, `omega_exp`, `plus`, and friends) all delegate to it. Reach
+    /// for `term` directly only when none of the convenience methods fit your
+    /// use case.
+    ///
+    /// Terms must be added in strictly decreasing exponent order. If a term
+    /// violates ordering or has zero multiplicity, the error is stored on the
+    /// builder and surfaced when [`build`](Self::build) is called rather than
+    /// panicking inline.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfinite::Ordinal;
+    ///
+    /// // ω² · 3 - equivalent to .omega_power_times(2, 3) but spelled in full.
+    /// let ordinal = Ordinal::builder()
+    ///     .term(Ordinal::new_finite(2), 3)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// assert!(ordinal.is_transfinite());
+    /// ```
     pub fn term(mut self, exponent: Ordinal, multiplicity: u32) -> Self {
         if self.error.is_some() {
             return self;

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 /// assert!(matches!(result, Err(OrdinalError::TransfiniteConstructionError)));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum OrdinalError {
     /// Error when constructing a CNF term with invalid parameters.
     ///

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -405,6 +405,36 @@ impl Ordinal {
         matches!(self, Ordinal::Transfinite(_))
     }
 
+    /// Returns `true` if this is the ordinal zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfinite::Ordinal;
+    ///
+    /// assert!(Ordinal::zero().is_zero());
+    /// assert!(!Ordinal::one().is_zero());
+    /// assert!(!Ordinal::omega().is_zero());
+    /// ```
+    pub fn is_zero(&self) -> bool {
+        matches!(self, Ordinal::Finite(0))
+    }
+
+    /// Returns `true` if this is the ordinal one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfinite::Ordinal;
+    ///
+    /// assert!(Ordinal::one().is_one());
+    /// assert!(!Ordinal::zero().is_one());
+    /// assert!(!Ordinal::omega().is_one());
+    /// ```
+    pub fn is_one(&self) -> bool {
+        matches!(self, Ordinal::Finite(1))
+    }
+
     /// Returns the leading (highest-order) CNF term, if this is a transfinite ordinal.
     ///
     /// For transfinite ordinals in CNF, the leading term has the largest exponent and
@@ -433,6 +463,28 @@ impl Ordinal {
         match self {
             Ordinal::Finite(_) => None,
             Ordinal::Transfinite(terms) => terms.first().cloned(),
+        }
+    }
+
+    /// Returns a reference to the leading CNF term, avoiding the clone that
+    /// [`leading_cnf_term`](Self::leading_cnf_term) performs.
+    ///
+    /// Prefer this method when you only need to inspect the leading term and
+    /// do not need to keep an owned copy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfinite::Ordinal;
+    ///
+    /// let omega = Ordinal::omega();
+    /// let leading = omega.leading_cnf_term_ref().unwrap();
+    /// assert_eq!(leading.multiplicity(), 1);
+    /// ```
+    pub fn leading_cnf_term_ref(&self) -> Option<&CnfTerm> {
+        match self {
+            Ordinal::Finite(_) => None,
+            Ordinal::Transfinite(terms) => terms.first(),
         }
     }
 
@@ -466,6 +518,25 @@ impl Ordinal {
         match self {
             Ordinal::Finite(_) => None,
             Ordinal::Transfinite(terms) => terms.last().cloned(),
+        }
+    }
+
+    /// Reference-returning variant of [`trailing_cnf_term`](Self::trailing_cnf_term);
+    /// see [`leading_cnf_term_ref`](Self::leading_cnf_term_ref) for the rationale.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfinite::Ordinal;
+    ///
+    /// let omega_plus_one = Ordinal::omega().successor();
+    /// let trailing = omega_plus_one.trailing_cnf_term_ref().unwrap();
+    /// assert_eq!(trailing.multiplicity(), 1);
+    /// ```
+    pub fn trailing_cnf_term_ref(&self) -> Option<&CnfTerm> {
+        match self {
+            Ordinal::Finite(_) => None,
+            Ordinal::Transfinite(terms) => terms.last(),
         }
     }
 
@@ -505,6 +576,31 @@ impl Ordinal {
         }
     }
 
+    /// Returns an iterator over the CNF terms without cloning.
+    ///
+    /// For finite ordinals the iterator is empty. For transfinite ordinals it
+    /// yields each term in CNF order (decreasing exponent). Prefer this over
+    /// [`cnf_terms`](Self::cnf_terms) when you only need to walk the terms
+    /// once.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfinite::Ordinal;
+    ///
+    /// let omega = Ordinal::omega();
+    /// assert_eq!(omega.cnf_terms_iter().count(), 1);
+    ///
+    /// let five = Ordinal::new_finite(5);
+    /// assert_eq!(five.cnf_terms_iter().count(), 0);
+    /// ```
+    pub fn cnf_terms_iter(&self) -> std::slice::Iter<'_, CnfTerm> {
+        match self {
+            Ordinal::Finite(_) => [].iter(),
+            Ordinal::Transfinite(terms) => terms.iter(),
+        }
+    }
+
     /// Returns the ordinal zero (0).
     ///
     /// Zero is the smallest ordinal and the only finite limit ordinal.
@@ -519,8 +615,8 @@ impl Ordinal {
     /// assert!(zero.is_limit());
     /// assert!(zero.is_finite());
     /// ```
-    pub fn zero() -> Self {
-        Ordinal::new_finite(0)
+    pub const fn zero() -> Self {
+        Ordinal::Finite(0)
     }
 
     /// Returns the ordinal one (1).
@@ -537,8 +633,8 @@ impl Ordinal {
     /// assert_eq!(one, Ordinal::zero().successor());
     /// assert!(one.is_successor());
     /// ```
-    pub fn one() -> Self {
-        Ordinal::new_finite(1)
+    pub const fn one() -> Self {
+        Ordinal::Finite(1)
     }
 
     /// Returns omega (ω), the first infinite ordinal.
@@ -638,6 +734,30 @@ impl std::fmt::Display for Ordinal {
 impl From<u32> for Ordinal {
     fn from(n: u32) -> Self {
         Ordinal::new_finite(n)
+    }
+}
+
+/// Identity for ordinal addition. Enables generic algorithms that need a
+/// zero value via [`num_traits::Zero`].
+impl num_traits::Zero for Ordinal {
+    fn zero() -> Self {
+        Ordinal::zero()
+    }
+
+    fn is_zero(&self) -> bool {
+        Ordinal::is_zero(self)
+    }
+}
+
+/// Identity for ordinal multiplication. Enables generic algorithms that need
+/// a one value via [`num_traits::One`].
+impl num_traits::One for Ordinal {
+    fn one() -> Self {
+        Ordinal::one()
+    }
+
+    fn is_one(&self) -> bool {
+        Ordinal::is_one(self)
     }
 }
 
@@ -1422,5 +1542,99 @@ mod tests {
             ordinal.unwrap_err(),
             OrdinalError::TransfiniteConstructionError
         ));
+    }
+
+    #[test]
+    fn test_is_zero() {
+        assert!(Ordinal::zero().is_zero());
+        assert!(!Ordinal::one().is_zero());
+        assert!(!Ordinal::new_finite(42).is_zero());
+        assert!(!Ordinal::omega().is_zero());
+    }
+
+    #[test]
+    fn test_is_one() {
+        assert!(Ordinal::one().is_one());
+        assert!(!Ordinal::zero().is_one());
+        assert!(!Ordinal::new_finite(42).is_one());
+        assert!(!Ordinal::omega().is_one());
+    }
+
+    #[test]
+    fn test_zero_one_are_const() {
+        const Z: Ordinal = Ordinal::zero();
+        const O: Ordinal = Ordinal::one();
+        assert_eq!(Z, Ordinal::new_finite(0));
+        assert_eq!(O, Ordinal::new_finite(1));
+    }
+
+    #[test]
+    fn test_num_traits_zero_one() {
+        use num_traits::{One, Zero};
+        assert_eq!(<Ordinal as Zero>::zero(), Ordinal::zero());
+        assert!(<Ordinal as Zero>::zero().is_zero());
+        assert!(!<Ordinal as Zero>::is_zero(&Ordinal::one()));
+
+        assert_eq!(<Ordinal as One>::one(), Ordinal::one());
+        assert!(<Ordinal as One>::is_one(&Ordinal::one()));
+        assert!(!<Ordinal as One>::is_one(&Ordinal::zero()));
+    }
+
+    #[test]
+    fn test_leading_cnf_term_ref() {
+        let omega = Ordinal::omega();
+        let leading = omega
+            .leading_cnf_term_ref()
+            .expect("omega has a leading term");
+        assert_eq!(leading.multiplicity(), 1);
+
+        // Returned reference matches the cloning variant.
+        assert_eq!(
+            omega.leading_cnf_term_ref().cloned(),
+            omega.leading_cnf_term()
+        );
+
+        // Finite ordinals have no terms.
+        assert!(Ordinal::new_finite(5).leading_cnf_term_ref().is_none());
+    }
+
+    #[test]
+    fn test_trailing_cnf_term_ref() {
+        let ordinal = Ordinal::new_transfinite(&[
+            CnfTerm::new(&Ordinal::new_finite(2), 1).unwrap(),
+            CnfTerm::new_finite(7),
+        ])
+        .unwrap();
+        let trailing = ordinal.trailing_cnf_term_ref().expect("has trailing term");
+        assert_eq!(trailing.multiplicity(), 7);
+
+        // Returned reference matches the cloning variant.
+        assert_eq!(
+            ordinal.trailing_cnf_term_ref().cloned(),
+            ordinal.trailing_cnf_term()
+        );
+
+        // Finite ordinals have no terms.
+        assert!(Ordinal::new_finite(5).trailing_cnf_term_ref().is_none());
+    }
+
+    #[test]
+    fn test_cnf_terms_iter() {
+        let omega = Ordinal::omega();
+        assert_eq!(omega.cnf_terms_iter().count(), 1);
+
+        // Finite ordinals iterate over zero terms.
+        assert_eq!(Ordinal::new_finite(5).cnf_terms_iter().count(), 0);
+        assert_eq!(Ordinal::zero().cnf_terms_iter().count(), 0);
+
+        // Iterator order matches cnf_terms vector order.
+        let three_term = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(3)
+            .plus(7)
+            .build()
+            .unwrap();
+        let from_iter: Vec<CnfTerm> = three_term.cnf_terms_iter().cloned().collect();
+        assert_eq!(Some(from_iter), three_term.cnf_terms());
     }
 }

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -1014,11 +1014,6 @@ impl Mul<&Ordinal> for &Ordinal {
 ///
 /// Finite ordinal exponentiation uses saturating arithmetic. Computing `m^n` for
 /// finite ordinals that would exceed `u32::MAX` returns `u32::MAX` instead of panicking.
-///
-/// # Panics
-///
-/// Panics on finite base with a transfinite exponent whose leading term has a
-/// transfinite exponent itself (e.g., `2^(ω^ω·3)`). This case is not yet implemented.
 impl Pow<Ordinal> for Ordinal {
     type Output = Self;
 
@@ -1110,7 +1105,21 @@ impl Pow<Ordinal> for Ordinal {
                                 )
                                 .expect("positive multiplicity for outer term")]);
                         } else {
-                            todo!("finite base with transfinite tower exponent (e.g., 2^(ω^ω·3))")
+                            // n^(ω^e · k) = ω^(ω^e · k) for transfinite e. The decrement
+                            // that the finite-e branch performs collapses here because
+                            // 1 + e = e for any transfinite e (left absorption of finite
+                            // into transfinite), so ω^(e-1) and ω^e coincide on this path.
+                            //
+                            // Reference: Carneiro,
+                            // https://math.stackexchange.com/q/2588262
+                            let inner_exp =
+                                Ordinal::transfinite_unchecked(vec![CnfTerm::from_parts(e, k)
+                                    .expect("positive multiplicity for inner exponent")]);
+                            distributed = distributed
+                                * Ordinal::transfinite_unchecked(vec![CnfTerm::from_parts(
+                                    inner_exp, 1,
+                                )
+                                .expect("positive multiplicity for outer term")]);
                         }
                     }
                 }

--- a/tests/comprehensive_tests.rs
+++ b/tests/comprehensive_tests.rs
@@ -739,4 +739,80 @@ mod integration_tests {
         assert!(ord1 < omega_omega);
         assert!(omega_omega < ord2);
     }
+
+    // ========================================
+    // FINITE-BASE TRANSFINITE-TOWER EXPONENTIATION
+    // ========================================
+    //
+    // Pre-0.3.0, raising a finite base ≥ 2 to an exponent containing a CNF
+    // term ω^β · v with β itself transfinite would hit a todo!() panic.
+    // The implementation rule, drawn from Carneiro's MathStackExchange answer
+    // (https://math.stackexchange.com/q/2588262) and Madore's reference Haskell
+    // code, is: for transfinite β, n^(ω^β · v) = ω^(ω^β · v) - the decrement
+    // present in the finite-β branch collapses because 1 + β = β.
+    //
+    // Verification strategy: each test computes 2^X via the new path and
+    // compares to ω^X computed via the existing transfinite-base path.
+    // Equality across these two independently derived expressions confirms
+    // the formula end-to-end.
+
+    #[test]
+    fn test_finite_pow_omega_to_omega() {
+        // 2^(ω^ω) = ω^(ω^ω)
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_omega = omega.clone().pow(omega.clone());
+        assert_eq!(two.pow(omega_omega.clone()), omega.pow(omega_omega));
+    }
+
+    #[test]
+    fn test_finite_pow_omega_omega_times_three() {
+        // 2^(ω^ω · 3) = ω^(ω^ω · 3) - the exact case the original review
+        // surfaced as the panicking input.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_omega = omega.clone().pow(omega.clone());
+        let exp = omega_omega * Ordinal::new_finite(3);
+        assert_eq!(two.pow(exp.clone()), omega.pow(exp));
+    }
+
+    #[test]
+    fn test_finite_pow_omega_to_omega_plus_one() {
+        // 2^(ω^(ω+1)) = ω^(ω^(ω+1)) - confirms "no decrement" is correct
+        // for transfinite successors, not only transfinite limits.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let exp = omega.clone().pow(omega.successor());
+        assert_eq!(two.pow(exp.clone()), omega.pow(exp));
+    }
+
+    #[test]
+    fn test_finite_pow_mixed_finite_transfinite_terms() {
+        // 2^(ω^ω + ω + 5) = ω^(ω^ω + 1) · 32
+        // Three CNF terms of three different types in the same exponent.
+        // Verifies the loop combines all three contribution types correctly:
+        //   ω^ω · 1   (transfinite e)  → ω^(ω^ω)
+        //   ω · 1     (e = 1)          → ω
+        //   5         (finite term)    → 2^5 = 32
+        // Then ω^(ω^ω) · ω = ω^(ω^ω + 1), and · 32 scales the multiplicity.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_omega = omega.clone().pow(omega.clone());
+        let exp = omega_omega.clone() + omega.clone() + Ordinal::new_finite(5);
+
+        let result = two.pow(exp);
+        let expected = omega.pow(omega_omega + Ordinal::one()) * Ordinal::new_finite(32);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_finite_pow_omega_squared_inner() {
+        // 2^(ω^(ω²)) = ω^(ω^(ω²)) - confirms the formula doesn't depend on
+        // the inner exponent being structurally simple.
+        let two = Ordinal::new_finite(2);
+        let omega = Ordinal::omega();
+        let omega_squared = omega.clone().pow(Ordinal::new_finite(2));
+        let exp = omega.clone().pow(omega_squared);
+        assert_eq!(two.pow(exp.clone()), omega.pow(exp));
+    }
 }

--- a/tests/comprehensive_tests.rs
+++ b/tests/comprehensive_tests.rs
@@ -815,4 +815,88 @@ mod integration_tests {
         let exp = omega.clone().pow(omega_squared);
         assert_eq!(two.pow(exp.clone()), omega.pow(exp));
     }
+
+    // ========================================
+    // COMPARISON: SHARED LEADING TERM
+    // ========================================
+    //
+    // Existing comparison tests focus on different leading terms or different
+    // arity. These exercise the recursive lexicographic compare path where the
+    // leading term is identical and the difference lies further down the CNF.
+
+    #[test]
+    fn test_comparison_same_leading_term_differing_multiplicity() {
+        // ω² + ω vs ω² + ω·2 - same first two exponent layers, multiplicity differs.
+        let lhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .build()
+            .unwrap();
+        let rhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(2)
+            .build()
+            .unwrap();
+        assert!(lhs < rhs);
+        assert!(rhs > lhs);
+    }
+
+    #[test]
+    fn test_comparison_same_leading_term_finite_vs_omega_tail() {
+        // ω² + 5 vs ω² + ω - finite tail loses to any transfinite tail.
+        let lhs = Ordinal::builder().omega_power(2).plus(5).build().unwrap();
+        let rhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .build()
+            .unwrap();
+        assert!(lhs < rhs);
+    }
+
+    #[test]
+    fn test_comparison_same_leading_term_differing_finite_tail() {
+        // ω² + ω + 5 vs ω² + ω + 100 - everything matches except trailing finite.
+        let lhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .plus(5)
+            .build()
+            .unwrap();
+        let rhs = Ordinal::builder()
+            .omega_power(2)
+            .omega_times(1)
+            .plus(100)
+            .build()
+            .unwrap();
+        assert!(lhs < rhs);
+    }
+
+    #[test]
+    fn test_comparison_same_leading_strict_prefix() {
+        // ω² < ω² + 1 - shared leading term, rhs has extra trailing term.
+        let lhs = Ordinal::builder().omega_power(2).build().unwrap();
+        let rhs = Ordinal::builder().omega_power(2).plus(1).build().unwrap();
+        assert!(lhs < rhs);
+    }
+
+    // ========================================
+    // DEEP EXPONENT DISPLAY
+    // ========================================
+
+    #[test]
+    fn test_deep_exponent_display() {
+        // ω^(ω^(ω+1)) - three nested levels exercise the recursive Display path.
+        let omega = Ordinal::omega();
+        let omega_plus_one = omega.successor();
+        let inner = omega.clone().pow(omega_plus_one);
+        let nested = omega.pow(inner);
+
+        let formatted = format!("{}", nested);
+
+        // Sanity: contains omega glyph and an exponent marker.
+        assert!(formatted.contains('ω'), "expected ω in: {formatted}");
+        assert!(formatted.contains('^'), "expected ^ in: {formatted}");
+        // The innermost ω+1 should still be visible.
+        assert!(formatted.contains("+ 1"), "expected '+ 1' in: {formatted}");
+    }
 }

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -341,3 +341,46 @@ fn test_reference_exponentiation() {
     assert_eq!((&two).pow(three.clone()), Ordinal::new_finite(8));
     assert_eq!(two.pow(three), Ordinal::new_finite(8));
 }
+
+// ========================================
+// SATURATING ARITHMETIC AT u32::MAX
+// ========================================
+//
+// Finite ordinal arithmetic is documented to saturate at u32::MAX rather than
+// panic on overflow. These tests pin the contract at the boundary so a future
+// switch to checked or wrapping arithmetic would fail loudly here.
+
+#[test]
+fn test_finite_pow_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    let two = Ordinal::new_finite(2);
+    assert_eq!(big.pow(two), Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_pow_large_exponent_saturates() {
+    // 2^32 already exceeds u32::MAX; 2^1000 must saturate.
+    let two = Ordinal::new_finite(2);
+    let thousand = Ordinal::new_finite(1000);
+    assert_eq!(two.pow(thousand), Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_mul_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    let two = Ordinal::new_finite(2);
+    assert_eq!(big * two, Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_add_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    let one = Ordinal::one();
+    assert_eq!(big + one, Ordinal::new_finite(u32::MAX));
+}
+
+#[test]
+fn test_finite_successor_saturates_at_max() {
+    let big = Ordinal::new_finite(u32::MAX);
+    assert_eq!(big.successor(), Ordinal::new_finite(u32::MAX));
+}


### PR DESCRIPTION
## Summary

Cumulative 0.3.0 release. Bundles eight wave PRs (#10-#17) plus the
version/README/CHANGELOG bump.

### Highlights

- **Implementation**: closes the only remaining `todo!()` in the `Pow`
  impl. `n^(ω^β · k)` for transfinite `β` (e.g. `2^(ω^ω · 3)`) now
  computes correctly instead of panicking. Math derived from Carneiro's
  [math.stackexchange answer](https://math.stackexchange.com/q/2588262)
  and Madore's reference Haskell code.
- **API additions** (all additive): `num_traits::Zero` and `One` impls,
  `is_zero()`, `leading_cnf_term_ref()` / `trailing_cnf_term_ref()`,
  `cnf_terms_iter()`, `const fn zero()` / `const fn one()`.
- **Breaking**: `OrdinalError` is now `#[non_exhaustive]` so future
  variants don't require a major version bump.
- **Examples**: three new runnable demos under `examples/` -
  `goodstein`, `hydra`, `epsilon_zero`.
- **Benchmarks**: criterion suite at `benches/ordinal_bench.rs` (run
  with `cargo bench`).
- **Tests**: shared-leading comparison, deep exponent display, finite
  saturation at `u32::MAX`.
- **Release pipeline**: `cargo publish --locked`, OIDC trusted
  publishing replaces long-lived `CARGO_REGISTRY_TOKEN`, `Security
  Audit` job has the `checks: write` permission it needs.

### Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` - 208 tests pass (55 unit + 50 + 30 + 13 + 2
      integration + 58 doc)
- [x] `cargo build --release`
- [x] All four examples (`exponentiation`, `goodstein`, `hydra`,
      `epsilon_zero`) run successfully

## Test plan

- [ ] Cumulative diff review against `main`
- [ ] After merge: tag `v0.3.0` on `main` and confirm
      `Publish to crates.io` workflow succeeds via OIDC
- [ ] Confirm https://docs.rs/transfinite/0.3.0 renders
- [ ] Create GitHub Release at
      https://github.com/niarenaw/rust-transfinite/releases/new
      with the 0.3.0 CHANGELOG entry

## Bundled PRs

- #10 Wave 1: `cargo publish --locked`
- #11 Wave 2: `OrdinalBuilder::term` docs + CHANGELOG comparison links
- #12 Wave 3: additive API surface + `#[non_exhaustive]`
- #13 Wave 4: criterion benchmark suite
- #14 Wave 5a: finite^transfinite-tower exponentiation implementation
- #15 Wave 6: comparison + display + saturation test coverage
- #16 Wave 7: Goodstein, Hydra, ε₀ examples
- #17 Wave 8: OIDC trusted publishing + audit-job permission fix